### PR TITLE
Add Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,148 @@
+name: Docker
+
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*.*.*'
+    paths:
+      - docker/Dockerfile
+      - docker/docker-entrypoint.sh
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+
+env:
+  DOCKER_FILE: docker/Dockerfile
+  DOCKER_REPO: codexstorage/cs-codex-dist-tests
+
+
+jobs:
+  # Build platform specific image
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+        include:
+          - target:
+              os: linux
+              arch: amd64
+            builder: ubuntu-22.04
+          - target:
+              os: linux
+              arch: arm64
+            builder: buildjet-4vcpu-ubuntu-2204-arm
+
+    name: Build ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    runs-on: ${{ matrix.builder }}
+    outputs:
+      tags-linux-amd64: ${{ steps.tags.outputs.tags-linux-amd64 }}
+      tags-linux-arm64: ${{ steps.tags.outputs.tags-linux-arm64 }}
+    env:
+      PLATFORM: ${{ format('{0}/{1}', 'linux', matrix.target.arch) }}
+      SUFFIX: ${{ format('{0}-{1}', 'linux', matrix.target.arch) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker - Meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_REPO }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},suffix=-${{ env.SUFFIX }}
+            type=sha,suffix=-${{ env.SUFFIX }},enable=${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Docker - Set tags output
+        id: tags
+        run: |
+          if [[ '${{ matrix.target.os }}' == 'linux' && '${{ matrix.target.arch }}' == 'amd64' ]]; then
+            echo "tags-linux-amd64=${{ steps.meta.outputs.tags }}" >> "$GITHUB_OUTPUT"
+          elif [[ '${{ matrix.target.os }}' == 'linux' && '${{ matrix.target.arch }}' == 'arm64' ]]; then
+            echo "tags-linux-arm64=${{ steps.meta.outputs.tags }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Docker - Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker - Build and export to Docker
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.PLATFORM }}
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Docker - Minify image
+        uses: kitabisa/docker-slim-action@v1
+        id: slim
+        env:
+          DSLIM_HTTP_PROBE: false
+        with:
+          target: ${{ steps.meta.outputs.tags }}
+          overwrite: true
+
+      - name: Docker - Show slim report
+        run: echo "${REPORT}" | jq -r
+        env:
+          REPORT: ${{ steps.slim.outputs.report }}
+
+      - name: Docker - Push to Docker registry
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.PLATFORM }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # Publish single image
+  publish:
+    name: Push single image
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Docker - Meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_REPO }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Docker - Set tags
+        run: |
+          # Transform multi-line tags in to the comma-seperated
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ',' | awk '{gsub(/,$/,"");}1')
+          echo "TAGS=${TAGS}" >>$GITHUB_ENV
+
+      - name: Docker - Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker - Create and push manifest images
+        uses: Noelware/docker-manifest-action@master
+        with:
+          inputs: ${{ env.TAGS }}
+          images: ${{ needs.build.outputs.tags-linux-amd64 }},${{ needs.build.outputs.tags-linux-arm64 }}
+          push: true
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0
+
+COPY --chmod=0755 docker/docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["dotnet", "test"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,59 @@
+# Run tests with Docker in Kubernetes
+
+We may [run tests localy](../LOCALSETUP.MD) using installed Dotnet and inside Kubernetes we may use a [prepared Docker images](https://hub.docker.com/repository/docker/codexstorage/cs-codex-dist-tests).
+
+
+Custom [entrypoint](docker-entrypoint.sh) will do the following
+ 1. Clone repository
+ 2. Switch to the specific branch - `master` by default
+ 3. Run all tests - `dotnet test`
+
+**Run with defaults**
+```bash
+docker run \
+  --rm \
+  --name cs-codex-dist-tests \
+  codexstorage/cs-codex-dist-tests:sha-686757e
+```
+
+**Just short tests**
+```bash
+docker run \
+  --rm \
+  --name cs-codex-dist-tests \
+  codexstorage/cs-codex-dist-tests:sha-686757e \
+  dotnet test Tests
+```
+
+**Custom branch**
+```bash
+docker run \
+  --rm \
+  --name cs-codex-dist-tests \
+  --env BRANCH=feature/tests \
+  codexstorage/cs-codex-dist-tests:sha-686757e
+```
+
+**Custom local config**
+```bash
+docker run \
+  --rm \
+  --name cs-codex-dist-tests \
+  --env CONFIG=/opt/Configuration.cs \
+  --env CONFIG_SHOW=true \
+  --volume $PWD/DistTestCore/Configuration.cs:/opt/Configuration.cs \
+  codexstorage/cs-codex-dist-tests:sha-686757e
+```
+
+**Local kubeconfig with custom local config**
+```bash
+docker run \
+  --rm \
+  --name cs-codex-dist-tests \
+  --env CONFIG=/opt/Configuration.cs \
+  --env CONFIG_SHOW=true \
+  --env SOURCE=https://github.com/codex-storage/cs-codex-dist-tests.git \
+  --volume $PWD/DistTestCore/Configuration.cs:/opt/Configuration.cs \
+  --volume $PWD/kubeconfig.yml:/opt/kubeconfig.yml \
+  codexstorage/cs-codex-dist-tests:sha-686757e
+```

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Variables
+SOURCE="${SOURCE:-https://github.com/codex-storage/cs-codex-dist-tests.git}"
+BRANCH="${BRANCH:-master}"
+FOLDER="${FOLDER:-/opt/dist-tests}"
+
+
+# Get tests
+echo "Clone ${SOURCE}"
+git clone -b "${BRANCH}" "${SOURCE}" "${FOLDER}"
+[[ -n "${CONFIG}" ]] && { echo Link config "${CONFIG}"; ln --symbolic --force "${CONFIG}" "${FOLDER}/DistTestCore/Configuration.cs"; }
+[[ "${CONFIG_SHOW}" == "true" ]] && { echo Show config "${CONFIG}"; cat "${FOLDER}/DistTestCore/Configuration.cs"; }
+cd "${FOLDER}"
+
+# Run
+echo "Run tests on branch '`git branch --show-current`' ..."
+exec "$@"
+


### PR DESCRIPTION
In order to run tests in Kubernetes, via Jobs, we need a Docker image with Dotnet installed.

We also should handle tests run via entrypoint.

This is just a start with some additional workaround like a config mount, until we will implement configuration options via CLI or environment variables.
