### PR TITLE
Fix/check network policies

### DIFF
--- a/DistTestCore/Codex/CodexContainerRecipe.cs
+++ b/DistTestCore/Codex/CodexContainerRecipe.cs
@@ -7,10 +7,10 @@ namespace DistTestCore.Codex
     public class CodexContainerRecipe : ContainerRecipeFactory
     {
         #if Arm64
-            public const string DockerImage = "emizzle/nim-codex-arm64:sha-c7af585";
+            public const string DockerImage = "codexstorage/nim-codex:sha-7b88ea0";
         #else
-			//public const string DockerImage = "thatbenbierens/nim-codex:sha-9716635";
-            public const string DockerImage = "thatbenbierens/codexlocal:latest";
+			//public const string DockerImage = "codexstorage/nim-codex:sha-7b88ea0";
+            public const string DockerImage = "codexstorage/nim-codex:sha-7b88ea0";
         #endif
         public const string MetricsPortTag = "metrics_port";
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Distributed System Tests for Nim-Codex
 
-Nim-Codex: https://github.com/status-im/nim-codex
+Nim-Codex: https://github.com/codex-storage/nim-codex
 
 Tests are built on dotnet v6.0 and Kubernetes v1.25.4, using dotnet-kubernetes SDK: https://github.com/kubernetes-client/csharp
 

--- a/codexnode-manifest.yml
+++ b/codexnode-manifest.yml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: codex-node1
-        image: thatbenbierens/nim-codex:sha-b204837
+        image: codexstorage/nim-codex:sha-7b88ea0
         ports:
         - containerPort: 8080
           name: api-1
@@ -38,7 +38,7 @@ spec:
         - name: LISTEN_ADDRS
           value: "/ip4/0.0.0.0/tcp/8082"
       - name: codex-node2
-        image: thatbenbierens/nim-codex:sha-b204837
+        image: codexstorage/nim-codex:sha-7b88ea0
         ports:
         - containerPort: 8083
           name: api-2


### PR DESCRIPTION
This PR close #12 

Proposed changes are based on [Network isolation during tests execution #11](#11)
 - Limit pods communication just inside same namespace
 - Permit DNS resolution
 - Permit HTTP and HTTP for nodes bootstrap (at least we can install packages for debug if required)

Network policies was tested in Kubernetes and they works as expected and looks like the following

```bash
k describe networkpolicy isolate-policy -n ct-00010
```
```yaml
Name:         isolate-policy
Namespace:    ct-00010
Created on:   2023-05-30 20:53:27 +0300 EEST
Labels:       <none>
Annotations:  <none>
Spec:
  PodSelector:     <none> (Allowing the specific traffic to all pods in this namespace)
  Allowing ingress traffic:
    To Port: <any> (traffic allowed to all ports)
    From:
      PodSelector: <none>
  Allowing egress traffic:
    To Port: <any> (traffic allowed to all ports)
    To:
      PodSelector: <none>
    ----------
    To Port: 53/UDP
    To:
      NamespaceSelector: kubernetes.io/metadata.name=kube-system
    To:
      PodSelector: k8s-app=kube-dns
    ----------
    To Port: 80/TCP
    To Port: 443/TCP
    To:
      IPBlock:
        CIDR: 0.0.0.0/0
        Except:
  Policy Types: Ingress, Egress
```

Also, as [we have Docker auto-builds for nim-codex](/codex-storage/nim-codex/issues/412#issuecomment-1557514748) now we can use them for tests as well.
