### PR TITLE
Allow access from runner namespace

### DIFF
--- a/KubernetesWorkflow/K8sController.cs
+++ b/KubernetesWorkflow/K8sController.cs
@@ -165,6 +165,19 @@ namespace KubernetesWorkflow
                                         PodSelector = new V1LabelSelector {}
                                     }
                                 }
+                            },
+                            new V1NetworkPolicyIngressRule
+                            {
+                                FromProperty = new List<V1NetworkPolicyPeer>
+                                {
+                                    new V1NetworkPolicyPeer
+                                    {
+                                        NamespaceSelector = new V1LabelSelector
+                                        {
+                                            MatchLabels = GetRunnerNamespaceSelector()
+                                        }
+                                    }
+                                }
                             }
                         },
                         Egress = new List<V1NetworkPolicyEgressRule>
@@ -308,6 +321,11 @@ namespace KubernetesWorkflow
         private IDictionary<string, string> GetSelector()
         {
             return new Dictionary<string, string> { { "codex-test-node", "dist-test-" + workflowNumberSource.WorkflowNumber } };
+        }
+
+        private IDictionary<string, string> GetRunnerNamespaceSelector()
+        {
+            return new Dictionary<string, string> { { "kubernetes.io/metadata.name", "default" } };
         }
 
         private V1ObjectMeta CreateDeploymentMetadata()


### PR DESCRIPTION
As we discussed, it will be required for runner to access pods in the namespaces where tests are running

I've reused the code I recently removed and in the future we probably should be able to make it fully dynamic based on the runner namespace. And initially it maybe enough to use a static value and use `default` namespace where we perform the tests.
```c#
        private IDictionary<string, string> GetRunnerNamespaceSelector()
        {
            return new Dictionary<string, string> { { "kubernetes.io/metadata.name", "default" } };
        }
```

<details>
<summary>resulting network policy</summary>

```yaml
Name:         isolate-policy
Namespace:    ct-00008
Created on:   2023-05-31 18:29:06 +0300 EEST
Labels:       <none>
Annotations:  <none>
Spec:
  PodSelector:     <none> (Allowing the specific traffic to all pods in this namespace)
  Allowing ingress traffic:
    To Port: <any> (traffic allowed to all ports)
    From:
      PodSelector: <none>
    ----------
    To Port: <any> (traffic allowed to all ports)
    From:
      NamespaceSelector: kubernetes.io/metadata.name=default
  Allowing egress traffic:
    To Port: <any> (traffic allowed to all ports)
    To:
      PodSelector: <none>
    ----------
    To Port: 53/UDP
    To:
      NamespaceSelector: kubernetes.io/metadata.name=kube-system
    To:
      PodSelector: k8s-app=kube-dns
    ----------
    To Port: 80/TCP
    To Port: 443/TCP
    To:
      IPBlock:
        CIDR: 0.0.0.0/0
        Except:
  Policy Types: Ingress, Egress
```
</details>

And a check from the default namespace to the pods during the tests run

<img width="1180" alt="Screenshot 2023-05-31 at 18 33 16" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/650d43cc-a093-4d01-a4ae-e848ebe8f1b7">
