### PR TITLE
Feature/fully connected download tests

### DIFF
--- a/DistTestCore/ByteSize.cs
+++ b/DistTestCore/ByteSize.cs
@@ -2,8 +2,11 @@
 {
     public class ByteSize
     {
+        private static readonly string[] sizeSuffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
+
         public ByteSize(long sizeInBytes)
         {
+            if (sizeInBytes < 0) throw new ArgumentException("Cannot create ByteSize object with size less than 0. Was: " + sizeInBytes);
             SizeInBytes = sizeInBytes;
         }
 
@@ -21,7 +24,11 @@
 
         public override string ToString()
         {
-            return $"{SizeInBytes} bytes";
+            if (SizeInBytes == 0) return "0" + sizeSuffixes[0];
+
+            var sizeOrder = Convert.ToInt32(Math.Floor(Math.Log(SizeInBytes, 1024)));
+            var digit = Math.Round(SizeInBytes / Math.Pow(1024, sizeOrder), 1);
+            return digit.ToString() + sizeSuffixes[sizeOrder];
         }
     }
 

--- a/DistTestCore/ByteSize.cs
+++ b/DistTestCore/ByteSize.cs
@@ -1,8 +1,9 @@
-﻿namespace DistTestCore
+﻿using Utils;
+
+namespace DistTestCore
 {
     public class ByteSize
     {
-        private static readonly string[] sizeSuffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
 
         public ByteSize(long sizeInBytes)
         {
@@ -29,11 +30,7 @@
 
         public override string ToString()
         {
-            if (SizeInBytes == 0) return "0" + sizeSuffixes[0];
-
-            var sizeOrder = Convert.ToInt32(Math.Floor(Math.Log(SizeInBytes, 1024)));
-            var digit = Math.Round(SizeInBytes / Math.Pow(1024, sizeOrder), 1);
-            return digit.ToString() + sizeSuffixes[sizeOrder];
+            return Formatter.FormatByteSize(SizeInBytes);
         }
     }
 

--- a/DistTestCore/ByteSize.cs
+++ b/DistTestCore/ByteSize.cs
@@ -12,6 +12,11 @@
 
         public long SizeInBytes { get; }
 
+        public long ToMB()
+        {
+            return SizeInBytes / (1024 * 1024);
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is ByteSize size && SizeInBytes == size.SizeInBytes;

--- a/DistTestCore/Codex/CodexContainerRecipe.cs
+++ b/DistTestCore/Codex/CodexContainerRecipe.cs
@@ -5,12 +5,12 @@ namespace DistTestCore.Codex
 {
     public class CodexContainerRecipe : ContainerRecipeFactory
     {
-        #if Arm64
+#if Arm64
             public const string DockerImage = "codexstorage/nim-codex:sha-7b88ea0";
-        #else
-			//public const string DockerImage = "codexstorage/nim-codex:sha-7b88ea0";
-            public const string DockerImage = "codexstorage/nim-codex:sha-7b88ea0";
-        #endif
+#else
+        public const string DockerImage = "thatbenbierens/nim-codex:dhting";
+        //public const string DockerImage = "codexstorage/nim-codex:sha-7b88ea0";
+#endif
         public const string MetricsPortTag = "metrics_port";
         public const string DiscoveryPortTag = "discovery-port";
 

--- a/DistTestCore/Codex/CodexContainerRecipe.cs
+++ b/DistTestCore/Codex/CodexContainerRecipe.cs
@@ -14,6 +14,10 @@ namespace DistTestCore.Codex
         public const string MetricsPortTag = "metrics_port";
         public const string DiscoveryPortTag = "discovery-port";
 
+        // Used by tests for time-constraint assersions.
+        public static readonly TimeSpan MaxUploadTimePerMegabyte = TimeSpan.FromSeconds(2.0);
+        public static readonly TimeSpan MaxDownloadTimePerMegabyte = TimeSpan.FromSeconds(2.0);
+
         protected override string Image => DockerImage;
 
         protected override void Initialize(StartupConfig startupConfig)

--- a/DistTestCore/DistTest.cs
+++ b/DistTestCore/DistTest.cs
@@ -87,9 +87,9 @@ namespace DistTestCore
             }
         }
 
-        public TestFile GenerateTestFile(ByteSize size)
+        public TestFile GenerateTestFile(ByteSize size, string label = "")
         {
-            return Get().FileManager.GenerateTestFile(size);
+            return Get().FileManager.GenerateTestFile(size, label);
         }
 
         /// <summary>

--- a/DistTestCore/DistTest.cs
+++ b/DistTestCore/DistTest.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 
 namespace DistTestCore
 {
-    [SetUpFixture]
     [Parallelizable(ParallelScope.All)]
     public abstract class DistTest
     {

--- a/DistTestCore/FileManager.cs
+++ b/DistTestCore/FileManager.cs
@@ -169,8 +169,9 @@ namespace DistTestCore
 
         public string Describe()
         {
-            if (!string.IsNullOrEmpty(Label)) return Label;
-            return $"'{Filename}' ({Formatter.FormatByteSize(GetFileSize())})";
+            var sizePostfix = $" ({Formatter.FormatByteSize(GetFileSize())})";
+            if (!string.IsNullOrEmpty(Label)) return Label + sizePostfix;
+            return $"'{Filename}'{sizePostfix}";
         }
 
         private void AssertEqual(TestFile? actual)
@@ -178,10 +179,7 @@ namespace DistTestCore
             if (actual == null) Assert.Fail("TestFile is null.");
             if (actual == this || actual!.Filename == Filename) Assert.Fail("TestFile is compared to itself.");
 
-            Stopwatch.Measure(log, "sizes", () =>
-            {
-                Assert.That(actual.GetFileSize(), Is.EqualTo(GetFileSize()), "Files are not of equal length.");
-            });
+            Assert.That(actual.GetFileSize(), Is.EqualTo(GetFileSize()), "Files are not of equal length.");
 
             using var streamExpected = new FileStream(Filename, FileMode.Open, FileAccess.Read);
             using var streamActual = new FileStream(actual.Filename, FileMode.Open, FileAccess.Read);

--- a/DistTestCore/FileManager.cs
+++ b/DistTestCore/FileManager.cs
@@ -43,7 +43,7 @@ namespace DistTestCore
         {
             var result = CreateEmptyTestFile(label);
             GenerateFileBytes(result, size);
-            log.Log($"Generated {size} of content for file '{result.Describe()}'.");
+            log.Log($"Generated file '{result.Describe()}'.");
             return result;
         }
 
@@ -117,12 +117,6 @@ namespace DistTestCore
         public string Filename { get; }
         public string Label { get; }
 
-        public long GetFileSize()
-        {
-            var info = new FileInfo(Filename);
-            return info.Length;
-        }
-
         public void AssertIsEqual(TestFile? actual)
         {
             if (actual == null) Assert.Fail("TestFile is null.");
@@ -157,7 +151,13 @@ namespace DistTestCore
         public string Describe()
         {
             if (!string.IsNullOrEmpty(Label)) return Label;
-            return Filename;
+            return $"'{Filename}' ({Formatter.FormatByteSize(GetFileSize())})";
+        }
+
+        private long GetFileSize()
+        {
+            var info = new FileInfo(Filename);
+            return info.Length;
         }
     }
 }

--- a/DistTestCore/FileManager.cs
+++ b/DistTestCore/FileManager.cs
@@ -43,7 +43,7 @@ namespace DistTestCore
         {
             var result = CreateEmptyTestFile(label);
             GenerateFileBytes(result, size);
-            log.Log($"Generated {size.SizeInBytes} bytes of content for file '{result.Describe()}'.");
+            log.Log($"Generated {size} of content for file '{result.Describe()}'.");
             return result;
         }
 

--- a/DistTestCore/Helpers/PeerConnectionTestHelpers.cs
+++ b/DistTestCore/Helpers/PeerConnectionTestHelpers.cs
@@ -16,10 +16,18 @@ namespace DistTestCore.Helpers
 
         public void AssertFullyConnected(IEnumerable<IOnlineCodexNode> nodes)
         {
-            AssertFullyConnected(nodes.ToArray());
+            var n = nodes.ToArray();
+
+            AssertFullyConnected(n);
+
+            for (int i = 0; i < 5; i++)
+            {
+                Time.Sleep(TimeSpan.FromSeconds(30));
+                AssertFullyConnected(n);
+            }
         }
 
-        public void AssertFullyConnected(params IOnlineCodexNode[] nodes)
+        private void AssertFullyConnected(IOnlineCodexNode[] nodes)
         {
             test.Log($"Asserting peers are fully-connected for nodes: '{string.Join(",", nodes.Select(n => n.GetName()))}'...");
             var entries = CreateEntries(nodes);

--- a/DistTestCore/Helpers/PeerDownloadTestHelpers.cs
+++ b/DistTestCore/Helpers/PeerDownloadTestHelpers.cs
@@ -1,4 +1,7 @@
-﻿namespace DistTestCore.Helpers
+﻿using Nethereum.Model;
+using NUnit.Framework;
+
+namespace DistTestCore.Helpers
 {
     public class PeerDownloadTestHelpers
     {
@@ -17,6 +20,8 @@
         public void AssertFullDownloadInterconnectivity(IEnumerable<IOnlineCodexNode> nodes, ByteSize testFileSize)
         {
             test.Log($"Asserting full download interconnectivity for nodes: '{string.Join(",", nodes.Select(n => n.GetName()))}'...");
+            var start = DateTime.UtcNow;
+
             foreach (var node in nodes)
             {
                 var uploader = node;
@@ -29,6 +34,19 @@
             }
             
             test.Log($"Success! Full download interconnectivity for nodes: {string.Join(",", nodes.Select(n => n.GetName()))}");
+            var timeTaken = DateTime.UtcNow - start;
+
+            AssertTimePerDownload(timeTaken, nodes.Count());
+        }
+
+        private void AssertTimePerDownload(TimeSpan timeTaken, int numberOfNodes)
+        {
+            var numberOfDownloads = numberOfNodes * (numberOfNodes - 1);
+            var timePerDownload = timeTaken / numberOfDownloads;
+
+            test.Log($"Performed {numberOfDownloads} downloads in {timeTaken.TotalSeconds} seconds, for an average of {timePerDownload.TotalSeconds} seconds per download.");
+
+            Assert.That(timePerDownload.TotalSeconds, Is.LessThan(20.0f), "Seconds-per-Download breached performance threshold.");
         }
 
         private void PerformTest(IOnlineCodexNode uploader, IOnlineCodexNode[] downloaders, ByteSize testFileSize)

--- a/DistTestCore/Helpers/PeerDownloadTestHelpers.cs
+++ b/DistTestCore/Helpers/PeerDownloadTestHelpers.cs
@@ -41,7 +41,7 @@ namespace DistTestCore.Helpers
             float sizeInMB = size.ToMB();
             var timePerMB = timePerDownload / sizeInMB;
 
-            test.Log($"Performed {numberOfDownloads} downloads of {size} in {timeTaken.TotalSeconds} seconds, for an average of {timePerMB} seconds per MB.");
+            test.Log($"Performed {numberOfDownloads} downloads of {size} in {timeTaken.TotalSeconds} seconds, for an average of {timePerMB.TotalSeconds} seconds per MB.");
 
             Assert.That(timePerMB, Is.LessThan(CodexContainerRecipe.MaxDownloadTimePerMegabyte), "MaxDownloadTimePerMegabyte performance threshold breached.");
         }

--- a/DistTestCore/Helpers/PeerDownloadTestHelpers.cs
+++ b/DistTestCore/Helpers/PeerDownloadTestHelpers.cs
@@ -33,8 +33,8 @@
 
         private void PerformTest(IOnlineCodexNode uploader, IOnlineCodexNode[] downloaders, ByteSize testFileSize)
         {
-            // 1 test file per downloader.
-            var files = downloaders.Select(d => test.GenerateTestFile(testFileSize)).ToArray();
+            // Generate 1 test file per downloader.
+            var files = downloaders.Select(d => GenerateTestFile(uploader, d, testFileSize)).ToArray();
 
             // Upload all the test files to the uploader.
             var contentIds = files.Select(uploader.UploadFile).ToArray();
@@ -43,10 +43,18 @@
             for (var i = 0; i < downloaders.Length; i++)
             {
                 var expectedFile = files[i];
-                var downloadedFile = downloaders[i].DownloadContent(contentIds[i]);
+                var downloadedFile = downloaders[i].DownloadContent(contentIds[i], $"{expectedFile.Label}DOWNLOADED");
 
                 expectedFile.AssertIsEqual(downloadedFile);
             }
+        }
+
+        private TestFile GenerateTestFile(IOnlineCodexNode uploader, IOnlineCodexNode downloader, ByteSize testFileSize)
+        {
+            var up = uploader.GetName().Replace("<", "").Replace(">", "");
+            var down = downloader.GetName().Replace("<", "").Replace(">", "");
+            var label = $"FROM{up}TO{down}";
+            return test.GenerateTestFile(testFileSize, label);
         }
     }
 }

--- a/DistTestCore/Helpers/PeerDownloadTestHelpers.cs
+++ b/DistTestCore/Helpers/PeerDownloadTestHelpers.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using DistTestCore.Codex;
+using NUnit.Framework;
 
 namespace DistTestCore.Helpers
 {
@@ -30,21 +31,19 @@ namespace DistTestCore.Helpers
             test.Log($"Success! Full download interconnectivity for nodes: {string.Join(",", nodes.Select(n => n.GetName()))}");
             var timeTaken = DateTime.UtcNow - start;
 
-            AssertTimePerDownload(timeTaken, nodes.Count(), testFileSize);
+            AssertTimePerMB(timeTaken, nodes.Count(), testFileSize);
         }
 
-        private void AssertTimePerDownload(TimeSpan timeTaken, int numberOfNodes, ByteSize size)
+        private void AssertTimePerMB(TimeSpan timeTaken, int numberOfNodes, ByteSize size)
         {
             var numberOfDownloads = numberOfNodes * (numberOfNodes - 1);
             var timePerDownload = timeTaken / numberOfDownloads;
-            float sizeInMB = size.SizeInBytes / (1024.0f * 1024.0f);
-            var timePerMB = timePerDownload.TotalSeconds / sizeInMB;
+            float sizeInMB = size.ToMB();
+            var timePerMB = timePerDownload / sizeInMB;
 
             test.Log($"Performed {numberOfDownloads} downloads of {size} in {timeTaken.TotalSeconds} seconds, for an average of {timePerMB} seconds per MB.");
 
-            var maxTimePerMB = 2.0f;
-
-            Assert.That(timePerMB, Is.LessThan(maxTimePerMB), "Seconds-per-MB performance threshold breached.");
+            Assert.That(timePerMB, Is.LessThan(CodexContainerRecipe.MaxDownloadTimePerMegabyte), "MaxDownloadTimePerMegabyte performance threshold breached.");
         }
 
         private void PerformTest(IOnlineCodexNode uploader, IOnlineCodexNode[] downloaders, ByteSize testFileSize)

--- a/DistTestCore/Marketplace/MarketplaceAccessFactory.cs
+++ b/DistTestCore/Marketplace/MarketplaceAccessFactory.cs
@@ -1,5 +1,4 @@
 ﻿using DistTestCore.Codex;
-using Logging;
 
 namespace DistTestCore.Marketplace
 {

--- a/DistTestCore/OnlineCodexNode.cs
+++ b/DistTestCore/OnlineCodexNode.cs
@@ -73,7 +73,9 @@ namespace DistTestCore
             {
                 Assert.Fail("Node failed to store block.");
             }
-            lifecycle.Log.AddStringReplace(response, $"(CID:{file.Describe()})");
+            var logReplacement = $"(CID:{file.Describe()})";
+            Log($"ContentId '{response}' is {logReplacement}");
+            lifecycle.Log.AddStringReplace(response, logReplacement);
             Log($"Uploaded file. Received contentId: '{response}'.");
             return new ContentId(response);
         }

--- a/DistTestCore/OnlineCodexNode.cs
+++ b/DistTestCore/OnlineCodexNode.cs
@@ -13,7 +13,7 @@ namespace DistTestCore
         CodexDebugPeerResponse GetDebugPeer(string peerId);
         CodexDebugPeerResponse GetDebugPeer(string peerId, TimeSpan timeout);
         ContentId UploadFile(TestFile file);
-        TestFile? DownloadContent(ContentId contentId);
+        TestFile? DownloadContent(ContentId contentId, string fileLabel = "");
         void ConnectToPeer(IOnlineCodexNode node);
         ICodexNodeLog DownloadLog();
         IMetricsAccess Metrics { get; }
@@ -66,23 +66,24 @@ namespace DistTestCore
 
         public ContentId UploadFile(TestFile file)
         {
-            Log($"Uploading file of size {file.GetFileSize()}...");
+            Log($"Uploading file '{file.Describe()}' of size {file.GetFileSize()}...");
             using var fileStream = File.OpenRead(file.Filename);
             var response = CodexAccess.UploadFile(fileStream);
             if (response.StartsWith(UploadFailedMessage))
             {
                 Assert.Fail("Node failed to store block.");
             }
+            lifecycle.Log.AddStringReplace(response, $"(CID:{file.Describe()})");
             Log($"Uploaded file. Received contentId: '{response}'.");
             return new ContentId(response);
         }
 
-        public TestFile? DownloadContent(ContentId contentId)
+        public TestFile? DownloadContent(ContentId contentId, string fileLabel = "")
         {
             Log($"Downloading for contentId: '{contentId.Id}'...");
-            var file = lifecycle.FileManager.CreateEmptyTestFile();
+            var file = lifecycle.FileManager.CreateEmptyTestFile(fileLabel);
             DownloadToFile(contentId.Id, file);
-            Log($"Downloaded file of size {file.GetFileSize()} to '{file.Filename}'.");
+            Log($"Downloaded file '{file.Describe()}' of size {file.GetFileSize()} to '{file.Filename}'.");
             return file;
         }
 

--- a/DistTestCore/OnlineCodexNode.cs
+++ b/DistTestCore/OnlineCodexNode.cs
@@ -69,7 +69,7 @@ namespace DistTestCore
         {
             using var fileStream = File.OpenRead(file.Filename);
 
-            var logMessage = $"Uploading file '{file.Describe()}' of size {file.GetFileSize()}...";
+            var logMessage = $"Uploading file {file.Describe()}...";
             var response = Stopwatch.Measure(lifecycle.Log, logMessage, () =>
             {
                 return CodexAccess.UploadFile(fileStream);
@@ -91,7 +91,7 @@ namespace DistTestCore
             var logMessage = $"Downloading for contentId: '{contentId.Id}'...";
             var file = lifecycle.FileManager.CreateEmptyTestFile(fileLabel);
             Stopwatch.Measure(lifecycle.Log, logMessage, () => DownloadToFile(contentId.Id, file));
-            Log($"Downloaded file '{file.Describe()}' of size {file.GetFileSize()} to '{file.Filename}'.");
+            Log($"Downloaded file {file.Describe()} to '{file.Filename}'.");
             return file;
         }
 

--- a/DistTestCore/Timing.cs
+++ b/DistTestCore/Timing.cs
@@ -31,7 +31,7 @@ namespace DistTestCore
 
         public TimeSpan HttpCallRetryDelay()
         {
-            return TimeSpan.FromSeconds(3);
+            return TimeSpan.FromSeconds(1);
         }
 
         public TimeSpan WaitForK8sServiceDelay()
@@ -64,7 +64,7 @@ namespace DistTestCore
 
         public TimeSpan HttpCallRetryDelay()
         {
-            return TimeSpan.FromMinutes(5);
+            return TimeSpan.FromSeconds(2);
         }
 
         public TimeSpan WaitForK8sServiceDelay()

--- a/KubernetesWorkflow/K8sController.cs
+++ b/KubernetesWorkflow/K8sController.cs
@@ -391,6 +391,7 @@ namespace KubernetesWorkflow
             {
                 Name = recipe.Name,
                 Image = recipe.Image,
+                ImagePullPolicy = "Always",
                 Ports = CreateContainerPorts(recipe),
                 Env = CreateEnv(recipe)
             };

--- a/Logging/Stopwatch.cs
+++ b/Logging/Stopwatch.cs
@@ -23,6 +23,14 @@ namespace Logging
             sw.End();
         }
 
+        public static T Measure<T>(BaseLog log, string name, Func<T> action, bool debug = false)
+        {
+            var sw = Begin(log, name, debug);
+            var result = action();
+            sw.End();
+            return result;
+        }
+
         public static Stopwatch Begin(BaseLog log)
         {
             return Begin(log, "");

--- a/LongTests/BasicTests/DownloadTests.cs
+++ b/LongTests/BasicTests/DownloadTests.cs
@@ -6,6 +6,25 @@ namespace TestsLong.BasicTests
     [TestFixture]
     public class DownloadTests : DistTest
     {
+        [Test]
+        [Combinatorial]
+        [UseLongTimeouts]
+        public void DownloadCorrectnessTest(
+            [Values(1, 10, 100, 1024)] int sizeInMB,
+            [Values(1, 10, 100, 1024)] int multiplier)
+        {
+            var size = (sizeInMB * multiplier).MB();
+
+            var expectedFile = GenerateTestFile(size);
+
+            var node = SetupCodexNode();
+            var cid = node.UploadFile(expectedFile);
+            var actualFile = node.DownloadContent(cid);
+
+            expectedFile.AssertIsEqual(actualFile);
+        }
+
+
         [TestCase(3, 500)]
         [TestCase(5, 100)]
         [TestCase(10, 256)]

--- a/LongTests/BasicTests/DownloadTests.cs
+++ b/LongTests/BasicTests/DownloadTests.cs
@@ -6,25 +6,6 @@ namespace TestsLong.BasicTests
     [TestFixture]
     public class DownloadTests : DistTest
     {
-        [Test]
-        [Combinatorial]
-        [UseLongTimeouts]
-        public void DownloadCorrectnessTest(
-            [Values(1, 10, 100, 1024)] int sizeInMB,
-            [Values(1, 10, 100, 1024)] int multiplier)
-        {
-            var size = (sizeInMB * multiplier).MB();
-
-            var expectedFile = GenerateTestFile(size);
-
-            var node = SetupCodexNode();
-            var cid = node.UploadFile(expectedFile);
-            var actualFile = node.DownloadContent(cid);
-
-            expectedFile.AssertIsEqual(actualFile);
-        }
-
-
         [TestCase(3, 500)]
         [TestCase(5, 100)]
         [TestCase(10, 256)]

--- a/LongTests/BasicTests/LargeFileTests.cs
+++ b/LongTests/BasicTests/LargeFileTests.cs
@@ -1,20 +1,47 @@
 ﻿using DistTestCore;
 using DistTestCore.Codex;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace TestsLong.BasicTests
 {
     [TestFixture]
     public class LargeFileTests : DistTest
     {
-        [Test]
-        [Combinatorial]
-        [UseLongTimeouts]
-        public void DownloadCorrectnessTest(
-            [Values(1, 10, 100, 1024)] int sizeInMB,
-            [Values(1, 10, 100, 1024)] int multiplier)
+        #region Abort test run after first failure
+
+        private bool stop;
+
+        [SetUp]
+        public void SetUp()
         {
-            long size = (sizeInMB * multiplier);
+            if (stop)
+            {
+                Assert.Inconclusive("Previous test failed");
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
+            {
+                stop = true;
+            }
+        }
+
+        #endregion
+
+        [TestCase(      1 *     1)] // 1 MB
+        [TestCase(      1 *    10)]
+        [TestCase(      1 *   100)]
+        [TestCase(      1 *  1024)] // 1 GB
+        [TestCase(   1024 *    10)]
+        [TestCase(   1024 *   100)]
+        [TestCase(   1024 *  1024)] // 1 TB :O
+        [UseLongTimeouts]
+        public void DownloadCorrectnessTest(long size)
+        {
             var sizeMB = size.MB();
 
             var expectedFile = GenerateTestFile(sizeMB);

--- a/LongTests/BasicTests/LargeFileTests.cs
+++ b/LongTests/BasicTests/LargeFileTests.cs
@@ -14,11 +14,12 @@ namespace TestsLong.BasicTests
             [Values(1, 10, 100, 1024)] int sizeInMB,
             [Values(1, 10, 100, 1024)] int multiplier)
         {
-            var size = (sizeInMB * multiplier).MB();
+            long size = (sizeInMB * multiplier);
+            var sizeMB = size.MB();
 
-            var expectedFile = GenerateTestFile(size);
+            var expectedFile = GenerateTestFile(sizeMB);
 
-            var node = SetupCodexNode();
+            var node = SetupCodexNode(s => s.WithStorageQuota((size + 10).MB()));
 
             var uploadStart = DateTime.UtcNow;
             var cid = node.UploadFile(expectedFile);
@@ -30,9 +31,9 @@ namespace TestsLong.BasicTests
             AssertTimeConstraint(uploadStart, downloadStart, downloadFinished, size);
         }
 
-        private void AssertTimeConstraint(DateTime uploadStart, DateTime downloadStart, DateTime downloadFinished, ByteSize size)
+        private void AssertTimeConstraint(DateTime uploadStart, DateTime downloadStart, DateTime downloadFinished, long size)
         {
-            float sizeInMB = size.ToMB();
+            float sizeInMB = size;
             var uploadTimePerMB = (uploadStart - downloadStart) / sizeInMB;
             var downloadTimePerMB = (downloadStart - downloadFinished) / sizeInMB;
 
@@ -41,7 +42,6 @@ namespace TestsLong.BasicTests
 
             Assert.That(downloadTimePerMB, Is.LessThan(CodexContainerRecipe.MaxDownloadTimePerMegabyte),
                 "MaxDownloadTimePerMegabyte performance threshold breached.");
-
         }
     }
 }

--- a/LongTests/BasicTests/LargeFileTests.cs
+++ b/LongTests/BasicTests/LargeFileTests.cs
@@ -1,4 +1,5 @@
 ﻿using DistTestCore;
+using DistTestCore.Codex;
 using NUnit.Framework;
 
 namespace TestsLong.BasicTests
@@ -6,19 +7,41 @@ namespace TestsLong.BasicTests
     [TestFixture]
     public class LargeFileTests : DistTest
     {
-        [Test, UseLongTimeouts]
-        public void OneClientLargeFileTest()
+        [Test]
+        [Combinatorial]
+        [UseLongTimeouts]
+        public void DownloadCorrectnessTest(
+            [Values(1, 10, 100, 1024)] int sizeInMB,
+            [Values(1, 10, 100, 1024)] int multiplier)
         {
-            var primary = SetupCodexNode(s => s
-                                .WithStorageQuota(20.GB()));
+            var size = (sizeInMB * multiplier).MB();
 
-            var testFile = GenerateTestFile(10.GB());
+            var expectedFile = GenerateTestFile(size);
 
-            var contentId = primary.UploadFile(testFile);
+            var node = SetupCodexNode();
 
-            var downloadedFile = primary.DownloadContent(contentId);
+            var uploadStart = DateTime.UtcNow;
+            var cid = node.UploadFile(expectedFile);
+            var downloadStart = DateTime.UtcNow;
+            var actualFile = node.DownloadContent(cid);
+            var downloadFinished = DateTime.UtcNow;
 
-            testFile.AssertIsEqual(downloadedFile);
+            expectedFile.AssertIsEqual(actualFile);
+            AssertTimeConstraint(uploadStart, downloadStart, downloadFinished, size);
+        }
+
+        private void AssertTimeConstraint(DateTime uploadStart, DateTime downloadStart, DateTime downloadFinished, ByteSize size)
+        {
+            float sizeInMB = size.ToMB();
+            var uploadTimePerMB = (uploadStart - downloadStart) / sizeInMB;
+            var downloadTimePerMB = (downloadStart - downloadFinished) / sizeInMB;
+
+            Assert.That(uploadTimePerMB, Is.LessThan(CodexContainerRecipe.MaxUploadTimePerMegabyte),
+                "MaxUploadTimePerMegabyte performance threshold breached.");
+
+            Assert.That(downloadTimePerMB, Is.LessThan(CodexContainerRecipe.MaxDownloadTimePerMegabyte),
+                "MaxDownloadTimePerMegabyte performance threshold breached.");
+
         }
     }
 }

--- a/LongTests/BasicTests/TestInfraTests.cs
+++ b/LongTests/BasicTests/TestInfraTests.cs
@@ -26,26 +26,5 @@ namespace TestsLong.BasicTests
                 Assert.That(!string.IsNullOrEmpty(n.GetDebugInfo().id));
             }
         }
-
-        [Test, UseLongTimeouts]
-        public void DownloadConsistencyTest()
-        {
-            var primary = SetupCodexNode(s => s
-                            .WithStorageQuota(2.MB()));
-
-            var testFile = GenerateTestFile(1.MB());
-
-            var contentId = primary.UploadFile(testFile);
-
-            var files = new List<TestFile?>();
-            for (var i = 0; i < 100; i++)
-            {
-                files.Add(primary.DownloadContent(contentId));
-            }
-
-            Assert.That(files.All(f => f != null));
-            Assert.That(files.All(f => f!.GetFileSize() == testFile.GetFileSize()));
-            foreach (var file in files) file!.AssertIsEqual(testFile);
-        }
     }
 }

--- a/LongTests/Parallelism.cs
+++ b/LongTests/Parallelism.cs
@@ -1,0 +1,6 @@
+﻿using NUnit.Framework;
+
+[assembly: LevelOfParallelism(1)]
+namespace Tests
+{
+}

--- a/Tests/DownloadConnectivityTests/FullyConnectedDownloadTests.cs
+++ b/Tests/DownloadConnectivityTests/FullyConnectedDownloadTests.cs
@@ -6,14 +6,15 @@ namespace Tests.DownloadConnectivityTests
     [TestFixture]
     public class FullyConnectedDownloadTests : AutoBootstrapDistTest
     {
-        [TestCase(3)]
-        [TestCase(10)]
-        [TestCase(20)]
-        public void FullyConnectedDownloadTest(int numberOfNodes)
+        [Test]
+        [Combinatorial]
+        public void FullyConnectedDownloadTest(
+            [Values(3, 10, 20)] int numberOfNodes,
+            [Values(1, 10, 100)] int sizeMBs)
         {
             for (var i = 0; i < numberOfNodes; i++) SetupCodexNode();
 
-            PeerDownloadTestHelpers.AssertFullDownloadInterconnectivity(GetAllOnlineCodexNodes());
+            PeerDownloadTestHelpers.AssertFullDownloadInterconnectivity(GetAllOnlineCodexNodes(), sizeMBs.MB());
         }
     }
 }

--- a/Tests/DownloadConnectivityTests/FullyConnectedDownloadTests.cs
+++ b/Tests/DownloadConnectivityTests/FullyConnectedDownloadTests.cs
@@ -1,0 +1,19 @@
+﻿using DistTestCore;
+using NUnit.Framework;
+
+namespace Tests.DownloadConnectivityTests
+{
+    [TestFixture]
+    public class FullyConnectedDownloadTests : AutoBootstrapDistTest
+    {
+        [TestCase(3)]
+        [TestCase(10)]
+        [TestCase(20)]
+        public void FullyConnectedDownloadTest(int numberOfNodes)
+        {
+            for (var i = 0; i < numberOfNodes; i++) SetupCodexNode();
+
+            PeerDownloadTestHelpers.AssertFullDownloadInterconnectivity(GetAllOnlineCodexNodes());
+        }
+    }
+}

--- a/Tests/PeerDiscoveryTests/LayeredDiscoveryTests.cs
+++ b/Tests/PeerDiscoveryTests/LayeredDiscoveryTests.cs
@@ -1,7 +1,6 @@
 ﻿using DistTestCore;
 using DistTestCore.Helpers;
 using NUnit.Framework;
-using Utils;
 
 namespace Tests.PeerDiscoveryTests
 {
@@ -35,7 +34,6 @@ namespace Tests.PeerDiscoveryTests
         [TestCase(5)]
         [TestCase(10)]
         [TestCase(20)]
-        [TestCase(50)]
         public void NodeChainTest(int chainLength)
         {
             var node = SetupCodexNode();
@@ -45,12 +43,6 @@ namespace Tests.PeerDiscoveryTests
             }
 
             AssertAllNodesConnected();
-
-            for (int i = 0; i < 5; i++)
-            {
-                Time.Sleep(TimeSpan.FromSeconds(30));
-                AssertAllNodesConnected();
-            }
         }
 
         private void AssertAllNodesConnected()

--- a/Tests/PeerDiscoveryTests/LayeredDiscoveryTests.cs
+++ b/Tests/PeerDiscoveryTests/LayeredDiscoveryTests.cs
@@ -56,7 +56,6 @@ namespace Tests.PeerDiscoveryTests
         private void AssertAllNodesConnected()
         {
             PeerConnectionTestHelpers.AssertFullyConnected(GetAllOnlineCodexNodes());
-            //PeerDownloadTestHelpers.AssertFullDownloadInterconnectivity(GetAllOnlineCodexNodes());
         }
     }
 }

--- a/Tests/PeerDiscoveryTests/PeerDiscoveryTests.cs
+++ b/Tests/PeerDiscoveryTests/PeerDiscoveryTests.cs
@@ -21,16 +21,6 @@ namespace Tests.PeerDiscoveryTests
         [TestCase(2)]
         [TestCase(3)]
         [TestCase(10)]
-        public void VariableNodes(int number)
-        {
-            SetupCodexNodes(number);
-
-            AssertAllNodesConnected();
-        }
-
-        [TestCase(2)]
-        [TestCase(3)]
-        [TestCase(10)]
         [TestCase(20)]
         public void VariableNodesInPods(int number)
         {
@@ -40,28 +30,6 @@ namespace Tests.PeerDiscoveryTests
             }
 
             AssertAllNodesConnected();
-        }
-
-        [TestCase(3, 3)]
-        [TestCase(3, 5)]
-        [TestCase(3, 10)]
-        [TestCase(5, 10)]
-        [TestCase(3, 20)]
-        [TestCase(5, 20)]
-        public void StagedVariableNodes(int numberOfNodes, int numberOfStages)
-        {
-            for (var i = 0; i < numberOfStages; i++)
-            {
-                SetupCodexNodes(numberOfNodes);
-
-                AssertAllNodesConnected();
-            }
-
-            for (int i = 0; i < 5; i++)
-            {
-                Time.Sleep(TimeSpan.FromSeconds(30));
-                AssertAllNodesConnected();
-            }
         }
 
         private void AssertAllNodesConnected()

--- a/Tests/PeerDiscoveryTests/PeerDiscoveryTests.cs
+++ b/Tests/PeerDiscoveryTests/PeerDiscoveryTests.cs
@@ -67,7 +67,6 @@ namespace Tests.PeerDiscoveryTests
         private void AssertAllNodesConnected()
         {
             PeerConnectionTestHelpers.AssertFullyConnected(GetAllOnlineCodexNodes());
-            //PeerDownloadTestHelpers.AssertFullDownloadInterconnectivity(GetAllOnlineCodexNodes());
         }
     }
 }

--- a/Utils/Formatter.cs
+++ b/Utils/Formatter.cs
@@ -1,0 +1,16 @@
+﻿namespace Utils
+{
+    public static class Formatter
+    {
+        private static readonly string[] sizeSuffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
+
+        public static string FormatByteSize(long bytes)
+        {
+            if (bytes == 0) return "0" + sizeSuffixes[0];
+
+            var sizeOrder = Convert.ToInt32(Math.Floor(Math.Log(bytes, 1024)));
+            var digit = Math.Round(bytes / Math.Pow(1024, sizeOrder), 1);
+            return digit.ToString() + sizeSuffixes[sizeOrder];
+        }
+    }
+}


### PR DESCRIPTION
Ben came up with a file exchange test which didn't seem to work.

The scenario was as follows:
You have a bunch of Codex nodes, within the bunch of nodes, you pick one node, generate a file for each of the other ones, upload all those files to the first node and task other nodes download files generated from the others, and repeat this process.

This fails immediately at 3 nodes and doesn't seem to propagate the manifests. First priority should be running stuff on the cluster w/ Slava and then focus on these download connectivity tests.

This draft PR should now resolve the failure of file exchange test outlined.