### PR TITLE
Add new variables to the job/pod

### DIFF
--- a/.github/workflows/dist-tests.yaml
+++ b/.github/workflows/dist-tests.yaml
@@ -15,19 +15,19 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: Branch
+        description: Branch (master)
         required: false
         type: string
       source:
-        description: Repository with tests
+        description: Repository with tests (current)
         required: false
         type: string
       nameprefix:
-        description: Runner job/pod name prefix
+        description: Runner prefix (cs-codex-dist-tests)
         required: false
         type: string
       namespace:
-        description: Kubernetes namespace for runner
+        description: Runner namespace (cs-codex-dist-tests)
         required: false
         type: string
 
@@ -56,6 +56,8 @@ jobs:
           [[ -n "${{ inputs.source }}" ]] && echo "SOURCE=${{ inputs.source }}" >>"$GITHUB_ENV" || echo "SOURCE=${{ env.SOURCE }}" >>"$GITHUB_ENV"
           [[ -n "${{ inputs.nameprefix }}" ]] && echo "NAMEPREFIX=${{ inputs.nameprefix }}" >>"$GITHUB_ENV" || echo "NAMEPREFIX=${{ env.NAMEPREFIX }}" >>"$GITHUB_ENV"
           [[ -n "${{ inputs.namespace }}" ]] && echo "NAMESPACE=${{ inputs.namespace }}" >>"$GITHUB_ENV" || echo "NAMESPACE=${{ env.NAMESPACE }}" >>"$GITHUB_ENV"
+          echo "RUNID=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
+          echo "TESTID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Kubectl - Install ${{ env.KUBE_VERSION }}
         uses: azure/setup-kubectl@v3
@@ -69,5 +71,4 @@ jobs:
 
       - name: Kubectl - Create Job
         run: |
-          export RUNID=$(date +%Y%m%d-%H%M%S)
           envsubst < ${{ env.JOB_MANIFEST }} | kubectl apply -f -

--- a/docker/job.yaml
+++ b/docker/job.yaml
@@ -28,6 +28,10 @@ spec:
           value: ${BRANCH}
         - name: SOURCE
           value: ${SOURCE}
+        - name: RUNID
+          value: ${RUNID}
+        - name: TESTID
+          value: ${TESTID}
         volumeMounts:
         - name: kubeconfig
           mountPath: /opt/kubeconfig.yaml


### PR DESCRIPTION
This PR adds new variables to the Kubernetes Job/Pod which was [recently added on app side](33). Ans some cosmetic changes to GitHub Actions job.

And it is a part of the [Adapt logs format to visualize dist-tests results in Kibana and Grafana #32](32 ).

It was tested and now we can see in Kibana/Grafana `Run ID` and `Test ID`
<img width="1413" alt="Screenshot 2023-07-21 at 10 00 52" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/d8a40e0a-c141-4e6a-9607-77b47cd79d00">
