### PR TITLE
Allow access from Prometheus namespace

### DIFF
--- a/KubernetesWorkflow/K8sController.cs
+++ b/KubernetesWorkflow/K8sController.cs
@@ -219,6 +219,19 @@ namespace KubernetesWorkflow
                                         }
                                     }
                                 }
+                            },
+                            new V1NetworkPolicyIngressRule
+                            {
+                                FromProperty = new List<V1NetworkPolicyPeer>
+                                {
+                                    new V1NetworkPolicyPeer
+                                    {
+                                        NamespaceSelector = new V1LabelSelector
+                                        {
+                                            MatchLabels = GetPrometheusNamespaceSelector()
+                                        }
+                                    }
+                                }
                             }
                         },
                         Egress = new List<V1NetworkPolicyEgressRule>
@@ -369,6 +382,11 @@ namespace KubernetesWorkflow
         private IDictionary<string, string> GetRunnerNamespaceSelector()
         {
             return new Dictionary<string, string> { { "kubernetes.io/metadata.name", "default" } };
+        }
+
+        private IDictionary<string, string> GetPrometheusNamespaceSelector()
+        {
+            return new Dictionary<string, string> { { "kubernetes.io/metadata.name", "monitoring" } };
         }
 
         private IDictionary<string, string> GetAnnotations(ContainerRecipe[] containerRecipes)


### PR DESCRIPTION
Closes #51.

This PR update Network Policy to allow access from Prometheus namespace for metrics scraping.

It was tested locally and on remote cluster.
- Policy created with an additional required rule
- Prometheus can access Codex Pods
- We can see metrics in Grafana

<details>
<summary>Screenshots</summary>

<img width="704" alt="Screenshot 2023-09-04 at 15 29 37" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/97636618-927e-4161-aa8e-07f98b2249fb">

<img width="1440" alt="Screenshot 2023-09-04 at 15 51 25" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/0ace61e8-6dd6-4cab-b7b7-ced70aa4c463">

<img width="1438" alt="Screenshot 2023-09-04 at 15 52 49" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/a11ac98f-a761-4e13-9ae4-3c78990342b5">

</details>