### PR TITLE
Fix Dist-Tests workflow inputs

### DIFF
--- a/.github/workflows/dist-tests.yaml
+++ b/.github/workflows/dist-tests.yaml
@@ -52,10 +52,10 @@ jobs:
 
       - name: Variables
         run: |
-          [[ -n "${{ inputs.branch }}" ]] && echo "BRANCH=${{ inputs.branch }}" >>"$GITHUB_ENV" || echo "BRANCH=${{ env.BRANCH }}" >>"$GITHUB_ENV"
-          [[ -n "${{ inputs.source }}" ]] && echo "SOURCE=${{ inputs.source }}" >>"$GITHUB_ENV" || echo "SOURCE=${{ env.SOURCE }}" >>"$GITHUB_ENV"
-          [[ -n "${{ inputs.nameprefix }}" ]] && echo "NAMEPREFIX=${{ inputs.nameprefix }}" >>"$GITHUB_ENV" || echo "NAMEPREFIX=${{ env.NAMEPREFIX }}" >>"$GITHUB_ENV"
-          [[ -n "${{ inputs.namespace }}" ]] && echo "NAMESPACE=${{ inputs.namespace }}" >>"$GITHUB_ENV" || echo "NAMESPACE=${{ env.NAMESPACE }}" >>"$GITHUB_ENV"
+          [[ -n "${{ github.event.inputs.branch }}" ]] && echo "BRANCH=${{ github.event.inputs.branch }}" >>"$GITHUB_ENV" || echo "BRANCH=${{ env.BRANCH }}" >>"$GITHUB_ENV"
+          [[ -n "${{ github.event.inputs.source }}" ]] && echo "SOURCE=${{ github.event.inputs.source }}" >>"$GITHUB_ENV" || echo "SOURCE=${{ env.SOURCE }}" >>"$GITHUB_ENV"
+          [[ -n "${{ github.event.inputs.nameprefix }}" ]] && echo "NAMEPREFIX=${{ github.event.inputs.nameprefix }}" >>"$GITHUB_ENV" || echo "NAMEPREFIX=${{ env.NAMEPREFIX }}" >>"$GITHUB_ENV"
+          [[ -n "${{ github.event.inputs.namespace }}" ]] && echo "NAMESPACE=${{ github.event.inputs.namespace }}" >>"$GITHUB_ENV" || echo "NAMESPACE=${{ env.NAMESPACE }}" >>"$GITHUB_ENV"
           echo "RUNID=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "TESTID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 


### PR DESCRIPTION
#### Context
This PR fixe Dist-Tests workflow inputs. Looks like it fail to create the job, because [Kubernetes unnecessarily requiring quoting on numeric env vars #82296](https://github.com/kubernetes/kubernetes/issues/82296).
```yaml
TESTID: 6115366
```
<details>
<summary>Screenshot</summary>

<img width="1412" alt="Screenshot 2023-09-06 at 19 16 20" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/4348b4df-691f-4c74-a3f3-bfed2bf4a026">
</details>

#### Fix
We have at least 2 ways to fix that
1. Update the manifest to quote the values
2. Switch to the `github.event.inputs` instead of the `inputs` - [Providing inputs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#providing-inputs)

We started from the second option as an easiest way to fix that. In case of need we also will apply the first option.

#### Additional
It worked nice before and probably just by coincidence, because this is the first time 'short sha' is just a number.
<details>
<summary>Screenshot</summary>

<img width="1341" alt="Screenshot 2023-09-06 at 19 27 58" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/e655b3f8-9299-468e-a3ef-4fa3b870c866">
</details>
