### PR TITLE
Fix Dist-Tests workflow input TESTID

### DIFF
--- a/docker/job.yaml
+++ b/docker/job.yaml
@@ -17,8 +17,6 @@ spec:
         image: codexstorage/cs-codex-dist-tests:latest
         imagePullPolicy: Always
         env:
-        - name: RUNNERLOCATION
-          value: InternalToCluster
         - name: KUBECONFIG
           value: /opt/kubeconfig.yaml
         - name: LOGPATH
@@ -32,7 +30,7 @@ spec:
         - name: RUNID
           value: ${RUNID}
         - name: TESTID
-          value: ${TESTID}
+          value: "${TESTID}"
         volumeMounts:
         - name: kubeconfig
           mountPath: /opt/kubeconfig.yaml


### PR DESCRIPTION
This is a second try to fix D-Tests inputs. In the [previous try](#54) we just switched to a different GitHub Actions variable.

But the right way is to set job variable `TESTID` to be a string.

We also removed `RUNNERLOCATION` variable which is not used anymore, because we already detect runner location automaticaly.
