### PR TITLE
[feature] Enable marketplace simulation of proof failures

### DIFF
--- a/DistTestCore/Codex/CodexContainerRecipe.cs
+++ b/DistTestCore/Codex/CodexContainerRecipe.cs
@@ -6,7 +6,7 @@ namespace DistTestCore.Codex
 {
     public class CodexContainerRecipe : DefaultContainerRecipe
     {
-        public const string DockerImage = "codexstorage/nim-codex:sha-dd67b74";
+        private const string DefaultDockerImage = "codexstorage/nim-codex:latest-dist-tests";
         public const string MetricsPortTag = "metrics_port";
         public const string DiscoveryPortTag = "discovery-port";
 

--- a/DistTestCore/Codex/CodexContainerRecipe.cs
+++ b/DistTestCore/Codex/CodexContainerRecipe.cs
@@ -79,10 +79,7 @@ namespace DistTestCore.Codex
             {
                 AddEnvVar("CODEX_SIMULATE_PROOF_FAILURES", config.SimulateProofFailures.ToString()!);
             }
-			// if (config.EnableValidator == true)
-            // {
-            //     AddEnvVar("CODEX_VALIDATOR", "true");
-            // }
+
             if (config.MarketplaceConfig != null)
             {
                 var gethConfig = startupConfig.Get<GethStartResult>();
@@ -103,9 +100,6 @@ namespace DistTestCore.Codex
                    AddEnvVar("CODEX_VALIDATOR", "true");
                 }
             }
-			// if (config.MarketplaceConfig != null) {
-            //     AddEnvVar("CODEX_PERSISTENCE", "true");
-            // }
 
             if(!string.IsNullOrEmpty(config.NameOverride)) {
                 AddEnvVar("CODEX_NODENAME", config.NameOverride);

--- a/DistTestCore/Codex/CodexContainerRecipe.cs
+++ b/DistTestCore/Codex/CodexContainerRecipe.cs
@@ -16,7 +16,7 @@ namespace DistTestCore.Codex
 
         public override string AppName => "codex";
         public override string Image { get; }
-        
+
         public CodexContainerRecipe()
         {
             Image = GetDockerImage();
@@ -75,7 +75,7 @@ namespace DistTestCore.Codex
                 AddPodAnnotation("prometheus.io/port", metricsPort.Number.ToString());
             }
 
-			if (config.SimulateProofFailures != null)
+            if (config.SimulateProofFailures != null)
             {
                 AddEnvVar("CODEX_SIMULATE_PROOF_FAILURES", config.SimulateProofFailures.ToString()!);
             }

--- a/DistTestCore/Codex/CodexContainerRecipe.cs
+++ b/DistTestCore/Codex/CodexContainerRecipe.cs
@@ -6,7 +6,7 @@ namespace DistTestCore.Codex
 {
     public class CodexContainerRecipe : DefaultContainerRecipe
     {
-        public const string DockerImage = "codexstorage/nim-codex:sha-1d161d3";
+        public const string DockerImage = "codexstorage/nim-codex:sha-dd67b74";
         public const string MetricsPortTag = "metrics_port";
         public const string DiscoveryPortTag = "discovery-port";
 
@@ -37,12 +37,7 @@ namespace DistTestCore.Codex
             AddVolume($"codex/{dataDir}", GetVolumeCapacity(config));
 
             AddInternalPortAndVar("CODEX_DISC_PORT", DiscoveryPortTag);
-
-            var level = config.LogLevel.ToString()!.ToUpperInvariant();
-            if (config.LogTopics != null && config.LogTopics.Count() > 0){
-                level = $"INFO;{level}: {string.Join(",", config.LogTopics.Where(s => !string.IsNullOrEmpty(s)))}";
-            }
-            AddEnvVar("CODEX_LOG_LEVEL", level);
+            AddEnvVar("CODEX_LOG_LEVEL", config.LogLevelWithTopics());
 
             // This makes the node announce itself to its local (pod) IP address.
             AddEnvVar("NAT_IP_AUTO", "true");
@@ -84,11 +79,11 @@ namespace DistTestCore.Codex
             {
                 AddEnvVar("CODEX_SIMULATE_PROOF_FAILURES", config.SimulateProofFailures.ToString()!);
             }
-			if (config.EnableValidator == true)
-            {
-                AddEnvVar("CODEX_VALIDATOR", "true");
-            }
-            if (config.MarketplaceConfig != null || config.EnableValidator == true)
+			// if (config.EnableValidator == true)
+            // {
+            //     AddEnvVar("CODEX_VALIDATOR", "true");
+            // }
+            if (config.MarketplaceConfig != null)
             {
                 var gethConfig = startupConfig.Get<GethStartResult>();
                 var companionNode = gethConfig.CompanionNode;
@@ -103,14 +98,14 @@ namespace DistTestCore.Codex
                 AddEnvVar("CODEX_MARKETPLACE_ADDRESS", gethConfig.MarketplaceNetwork.Marketplace.Address);
                 AddEnvVar("CODEX_PERSISTENCE", "true");
 
-                //if (config.MarketplaceConfig.IsValidator)
-                //{
-                //    AddEnvVar("CODEX_VALIDATOR", "true");
-                //}
+                if (config.MarketplaceConfig.IsValidator)
+                {
+                   AddEnvVar("CODEX_VALIDATOR", "true");
+                }
             }
-			if (config.MarketplaceConfig != null) {
-                AddEnvVar("CODEX_PERSISTENCE", "true");
-            }
+			// if (config.MarketplaceConfig != null) {
+            //     AddEnvVar("CODEX_PERSISTENCE", "true");
+            // }
 
             if(!string.IsNullOrEmpty(config.NameOverride)) {
                 AddEnvVar("CODEX_NODENAME", config.NameOverride);

--- a/DistTestCore/Codex/CodexStartupConfig.cs
+++ b/DistTestCore/Codex/CodexStartupConfig.cs
@@ -12,6 +12,16 @@ namespace DistTestCore.Codex
             LogLevel = logLevel;
         }
 
+        public string LogLevelWithTopics()
+        {
+            var level = LogLevel.ToString()!.ToUpperInvariant();
+            if (LogTopics != null && LogTopics.Count() > 0)
+            {
+                level = $"INFO;{level}: {string.Join(",", LogTopics.Where(s => !string.IsNullOrEmpty(s)))}";
+            }
+            return level;
+        }
+
         public string? NameOverride { get; set; }
         public Location Location { get; set; }
         public CodexLogLevel LogLevel { get; set; }

--- a/DistTestCore/Codex/CodexStartupConfig.cs
+++ b/DistTestCore/Codex/CodexStartupConfig.cs
@@ -14,12 +14,14 @@ namespace DistTestCore.Codex
 
         public string? NameOverride { get; set; }
         public Location Location { get; set; }
-        public CodexLogLevel LogLevel { get; }
+        public CodexLogLevel LogLevel { get; set; }
         public ByteSize? StorageQuota { get; set; }
         public MetricsMode MetricsMode { get; set; }
         public MarketplaceInitialConfig? MarketplaceConfig { get; set; }
         public string? BootstrapSpr { get; set; }
         public int? BlockTTL { get; set; }
+        public uint? SimulateProofFailures { get; set; }
+        public bool? EnableValidator { get; set; }
         public TimeSpan? BlockMaintenanceInterval { get; set; }
         public int? BlockMaintenanceNumber { get; set; }
     }

--- a/DistTestCore/Codex/CodexStartupConfig.cs
+++ b/DistTestCore/Codex/CodexStartupConfig.cs
@@ -15,6 +15,7 @@ namespace DistTestCore.Codex
         public string? NameOverride { get; set; }
         public Location Location { get; set; }
         public CodexLogLevel LogLevel { get; set; }
+        public string[]? LogTopics { get; set; }
         public ByteSize? StorageQuota { get; set; }
         public MetricsMode MetricsMode { get; set; }
         public MarketplaceInitialConfig? MarketplaceConfig { get; set; }

--- a/DistTestCore/CodexSetup.cs
+++ b/DistTestCore/CodexSetup.cs
@@ -24,7 +24,7 @@ namespace DistTestCore
         ICodexSetup EnableMarketplace(TestToken initialBalance);
         ICodexSetup EnableMarketplace(TestToken initialBalance, Ether initialEther);
         ICodexSetup EnableMarketplace(TestToken initialBalance, Ether initialEther, bool isValidator);
-		/// <summary>
+        /// <summary>
         /// Provides an invalid proof every N proofs
         /// </summary>
         ICodexSetup WithSimulateProofFailures(uint failEveryNProofs);

--- a/DistTestCore/CodexSetup.cs
+++ b/DistTestCore/CodexSetup.cs
@@ -18,8 +18,16 @@ namespace DistTestCore
         ICodexSetup EnableMarketplace(TestToken initialBalance);
         ICodexSetup EnableMarketplace(TestToken initialBalance, Ether initialEther);
         ICodexSetup EnableMarketplace(TestToken initialBalance, Ether initialEther, bool isValidator);
+		/// <summary>
+        /// Provides an invalid proof every N proofs
+        /// </summary>
+        ICodexSetup WithSimulateProofFailures(uint failEveryNProofs);
+        /// <summary>
+        /// Enables the validation module in the node
+        /// </summary>
+        ICodexSetup WithValidator();
     }
-    
+
     public class CodexSetup : CodexStartupConfig, ICodexSetup
     {
         public int NumberOfNodes { get; }
@@ -85,12 +93,24 @@ namespace DistTestCore
 
         public ICodexSetup EnableMarketplace(TestToken initialBalance, Ether initialEther)
         {
-            return EnableMarketplace(initialBalance, initialEther, false);
+			return EnableMarketplace(initialBalance, initialEther, false);
         }
 
         public ICodexSetup EnableMarketplace(TestToken initialBalance, Ether initialEther, bool isValidator)
         {
             MarketplaceConfig = new MarketplaceInitialConfig(initialEther, initialBalance, isValidator);
+            return this;
+        }
+
+        public ICodexSetup WithSimulateProofFailures(uint failEveryNProofs)
+        {
+            SimulateProofFailures = failEveryNProofs;
+            return this;
+        }
+
+        public ICodexSetup WithValidator()
+        {
+            EnableValidator = true;
             return this;
         }
 
@@ -104,7 +124,9 @@ namespace DistTestCore
         {
             yield return $"LogLevel={LogLevel}";
             if (BootstrapSpr != null) yield return $"BootstrapNode={BootstrapSpr}";
-            if (StorageQuota != null) yield return $"StorageQuote={StorageQuota}";
+            if (StorageQuota != null) yield return $"StorageQuota={StorageQuota}";
+            if (SimulateProofFailures != null) yield return $"SimulateProofFailures={SimulateProofFailures}";
+            if (EnableValidator != null) yield return $"EnableValidator={EnableValidator}";
         }
     }
 }

--- a/DistTestCore/CodexSetup.cs
+++ b/DistTestCore/CodexSetup.cs
@@ -31,7 +31,7 @@ namespace DistTestCore
         /// <summary>
         /// Enables the validation module in the node
         /// </summary>
-        ICodexSetup WithValidator();
+        // ICodexSetup WithValidator();
     }
 
     public class CodexSetup : CodexStartupConfig, ICodexSetup
@@ -127,11 +127,11 @@ namespace DistTestCore
             return this;
         }
 
-        public ICodexSetup WithValidator()
-        {
-            EnableValidator = true;
-            return this;
-        }
+        // public ICodexSetup WithValidator()
+        // {
+        //     EnableValidator = true;
+        //     return this;
+        // }
 
         public string Describe()
         {
@@ -141,11 +141,11 @@ namespace DistTestCore
 
         private IEnumerable<string> DescribeArgs()
         {
-            yield return $"LogLevel={LogLevel}";
+            yield return $"LogLevel={LogLevelWithTopics()}";
             if (BootstrapSpr != null) yield return $"BootstrapNode={BootstrapSpr}";
             if (StorageQuota != null) yield return $"StorageQuota={StorageQuota}";
             if (SimulateProofFailures != null) yield return $"SimulateProofFailures={SimulateProofFailures}";
-            if (EnableValidator != null) yield return $"EnableValidator={EnableValidator}";
+            if (MarketplaceConfig != null) yield return $"IsValidator={MarketplaceConfig.IsValidator}";
         }
     }
 }

--- a/DistTestCore/CodexSetup.cs
+++ b/DistTestCore/CodexSetup.cs
@@ -28,10 +28,6 @@ namespace DistTestCore
         /// Provides an invalid proof every N proofs
         /// </summary>
         ICodexSetup WithSimulateProofFailures(uint failEveryNProofs);
-        /// <summary>
-        /// Enables the validation module in the node
-        /// </summary>
-        // ICodexSetup WithValidator();
     }
 
     public class CodexSetup : CodexStartupConfig, ICodexSetup
@@ -112,7 +108,7 @@ namespace DistTestCore
 
         public ICodexSetup EnableMarketplace(TestToken initialBalance, Ether initialEther)
         {
-			return EnableMarketplace(initialBalance, initialEther, false);
+            return EnableMarketplace(initialBalance, initialEther, false);
         }
 
         public ICodexSetup EnableMarketplace(TestToken initialBalance, Ether initialEther, bool isValidator)
@@ -126,12 +122,6 @@ namespace DistTestCore
             SimulateProofFailures = failEveryNProofs;
             return this;
         }
-
-        // public ICodexSetup WithValidator()
-        // {
-        //     EnableValidator = true;
-        //     return this;
-        // }
 
         public string Describe()
         {

--- a/DistTestCore/CodexSetup.cs
+++ b/DistTestCore/CodexSetup.cs
@@ -9,6 +9,12 @@ namespace DistTestCore
     {
         ICodexSetup WithName(string name);
         ICodexSetup At(Location location);
+        ICodexSetup WithLogLevel(CodexLogLevel level);
+        /// <summary>
+        /// Sets the log level for codex. The default level is INFO and the
+        /// log level is applied only to the supplied topics.
+        /// </summary>
+        ICodexSetup WithLogLevel(CodexLogLevel level, params string[] topics);
         ICodexSetup WithBootstrapNode(IOnlineCodexNode node);
         ICodexSetup WithStorageQuota(ByteSize storageQuota);
         ICodexSetup WithBlockTTL(TimeSpan duration);
@@ -53,6 +59,19 @@ namespace DistTestCore
         public ICodexSetup WithBootstrapNode(IOnlineCodexNode node)
         {
             BootstrapSpr = node.GetDebugInfo().spr;
+            return this;
+        }
+
+        public ICodexSetup WithLogLevel(CodexLogLevel level)
+        {
+            LogLevel = level;
+            return this;
+        }
+
+        public ICodexSetup WithLogLevel(CodexLogLevel level, params string[] topics)
+        {
+            LogLevel = level;
+            LogTopics = topics;
             return this;
         }
 

--- a/DistTestCore/CodexStarter.cs
+++ b/DistTestCore/CodexStarter.cs
@@ -20,6 +20,7 @@ namespace DistTestCore
             LogSeparator();
             LogStart($"Starting {codexSetup.Describe()}...");
             var gethStartResult = lifecycle.GethStarter.BringOnlineMarketplaceFor(codexSetup);
+            gethStartResult = lifecycle.GethStarter.BringOnlineValidatorFor(codexSetup, gethStartResult);
 
             var startupConfig = CreateStartupConfig(gethStartResult, codexSetup);
 

--- a/DistTestCore/DistTestCore.csproj
+++ b/DistTestCore/DistTestCore.csproj
@@ -5,10 +5,6 @@
 	  <RootNamespace>DistTestCore</RootNamespace>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <Nullable>enable</Nullable>
-    <IsArm64 Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">true</IsArm64>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsArm64)'=='true'">
-    <DefineConstants>Arm64</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Metrics\dashboard.json" />

--- a/DistTestCore/GethStarter.cs
+++ b/DistTestCore/GethStarter.cs
@@ -30,6 +30,17 @@ namespace DistTestCore
             return CreateGethStartResult(marketplaceNetwork, companionNode);
         }
 
+        public GethStartResult BringOnlineValidatorFor(CodexSetup codexSetup, GethStartResult previousResult)
+        {
+            // allow marketplace and validator to be enabled on the same Codex node
+            if (previousResult.CompanionNode != null || (codexSetup.EnableValidator ?? false) == false) return previousResult;
+
+            var marketplaceNetwork = marketplaceNetworkCache.Get();
+            var companionNode = StartCompanionNode(codexSetup, marketplaceNetwork);
+
+            return CreateGethStartResult(marketplaceNetwork, companionNode);
+        }
+
         private void TransferInitialBalance(MarketplaceNetwork marketplaceNetwork, MarketplaceInitialConfig marketplaceConfig, GethCompanionNodeInfo companionNode)
         {
             if (marketplaceConfig.InitialTestTokens.Amount == 0) return;

--- a/DistTestCore/Marketplace/CodexContractsContainerRecipe.cs
+++ b/DistTestCore/Marketplace/CodexContractsContainerRecipe.cs
@@ -4,7 +4,6 @@ namespace DistTestCore.Marketplace
 {
     public class CodexContractsContainerRecipe : DefaultContainerRecipe
     {
-        public const string DockerImage = "codexstorage/dist-tests-codex-contracts-eth:sha-b4e4897";
         public const string MarketplaceAddressFilename = "/hardhat/deployments/codexdisttestnetwork/Marketplace.json";
         public const string MarketplaceArtifactFilename = "/hardhat/artifacts/contracts/Marketplace.sol/Marketplace.json";
 

--- a/DistTestCore/Marketplace/CodexContractsContainerRecipe.cs
+++ b/DistTestCore/Marketplace/CodexContractsContainerRecipe.cs
@@ -4,6 +4,7 @@ namespace DistTestCore.Marketplace
 {
     public class CodexContractsContainerRecipe : DefaultContainerRecipe
     {
+        public const string DockerImage = "codexstorage/dist-tests-codex-contracts-eth:sha-b4e4897";
         public const string MarketplaceAddressFilename = "/hardhat/deployments/codexdisttestnetwork/Marketplace.json";
         public const string MarketplaceArtifactFilename = "/hardhat/artifacts/contracts/Marketplace.sol/Marketplace.json";
 


### PR DESCRIPTION
- Enables simulating proof failures, which can be activated directly on the node in the test
- Allows for tests to filter node logs by topic to keep noise at a minimum
- Support codex node name override
- Add EnableValidator to codex node config