### PR TITLE
Add ability to download geth logs

### DIFF
--- a/DistTestCore/CodexNodeGroup.cs
+++ b/DistTestCore/CodexNodeGroup.cs
@@ -14,13 +14,14 @@ namespace DistTestCore
     {
         private readonly TestLifecycle lifecycle;
 
-        public CodexNodeGroup(TestLifecycle lifecycle, CodexSetup setup, RunningContainers[] containers, ICodexNodeFactory codexNodeFactory)
+        public CodexNodeGroup(TestLifecycle lifecycle, CodexSetup setup, RunningContainers[] containers, ICodexNodeFactory codexNodeFactory, RunningContainer gethContainer)
         {
             this.lifecycle = lifecycle;
             Setup = setup;
             Containers = containers;
             Nodes = containers.Containers().Select(c => CreateOnlineCodexNode(c, codexNodeFactory)).ToArray();
             Version = new CodexDebugVersionResponse();
+            GethContainer = gethContainer;
         }
 
         public IOnlineCodexNode this[int index]
@@ -46,6 +47,7 @@ namespace DistTestCore
 
         public CodexSetup Setup { get; private set; }
         public RunningContainers[] Containers { get; private set; }
+        public RunningContainer GethContainer { get; private set; }
         public OnlineCodexNode[] Nodes { get; private set; }
         public CodexDebugVersionResponse Version { get; private set; }
 

--- a/DistTestCore/CodexStarter.cs
+++ b/DistTestCore/CodexStarter.cs
@@ -29,7 +29,7 @@ namespace DistTestCore
             
             var codexNodeFactory = new CodexNodeFactory(lifecycle, metricAccessFactory, gethStartResult.MarketplaceAccessFactory);
 
-            var group = CreateCodexGroup(codexSetup, containers, codexNodeFactory);
+            var group = CreateCodexGroup(codexSetup, containers, codexNodeFactory, gethStartResult.CompanionNode.RunningContainer);
             lifecycle.SetCodexVersion(group.Version);
 
             var nl = Environment.NewLine;
@@ -107,9 +107,9 @@ namespace DistTestCore
             return result.ToArray();
         }
 
-        private CodexNodeGroup CreateCodexGroup(CodexSetup codexSetup, RunningContainers[] runningContainers, CodexNodeFactory codexNodeFactory)
+        private CodexNodeGroup CreateCodexGroup(CodexSetup codexSetup, RunningContainers[] runningContainers, CodexNodeFactory codexNodeFactory, RunningContainer gethContainer)
         {
-            var group = new CodexNodeGroup(lifecycle, codexSetup, runningContainers, codexNodeFactory);
+            var group = new CodexNodeGroup(lifecycle, codexSetup, runningContainers, codexNodeFactory, gethContainer);
             RunningGroups.Add(group);
 
             try

--- a/DistTestCore/OnlineCodexNode.cs
+++ b/DistTestCore/OnlineCodexNode.cs
@@ -17,6 +17,7 @@ namespace DistTestCore
         TestFile? DownloadContent(ContentId contentId, string fileLabel = "");
         void ConnectToPeer(IOnlineCodexNode node);
         IDownloadedLog DownloadLog(int? tailLines = null);
+        IDownloadedLog DownloadGethLog();
         IMetricsAccess Metrics { get; }
         IMarketplaceAccess Marketplace { get; }
         CodexDebugVersionResponse Version { get; }
@@ -106,6 +107,11 @@ namespace DistTestCore
         public IDownloadedLog DownloadLog(int? tailLines = null)
         {
             return lifecycle.DownloadLog(CodexAccess.Container, tailLines);
+        }
+
+        public IDownloadedLog DownloadGethLog()
+        {
+            return lifecycle.DownloadLog(Group.GethContainer);
         }
 
         public ICodexSetup BringOffline()


### PR DESCRIPTION
Since there is an upcoming refactor that will automatically download geth logs on test failure, this can be disregarded if the changes are better suited for the refactor. However, I needed these logs badly to understand what is happening in the marketplace interactions, so figured I'd open a PR and possibly help anyone else in the same boat.