### PR TITLE
Add basic documentation how to run Continuous Tests

### DIFF
--- a/docs/Automation.md
+++ b/docs/Automation.md
@@ -1,4 +1,4 @@
-# Distributed Tests automation
+# Tests automation
 
  1. [Description](#description)
  2. [Architecture](#architecture)
@@ -15,7 +15,7 @@
 
  We can [run Tests locally](LOCALSETUP.md) and it works well, but in order to scale that we may need to run Tests in an automatic way using remote Kubernetes cluster.
 
- Initially, we are considering to run dist-tests on [nim-codex](https://github.com/codex-storage/nim-codex) master branch merge, to be able to determine regressions. And we also working on [Continuous Tests](/ContinuousTests) which are called to detect issues on continuous Codex runs.
+ Initially, we are considering to run dist-tests on [nim-codex](https://github.com/codex-storage/nim-codex) master branch merge, to be able to determine regressions. And we also working on [Continuous Tests](Continuous-Tests.md) which are called to detect issues on continuous Codex runs.
 
 
 ## Architecture
@@ -23,12 +23,20 @@
 <img src="Architecture.png" alt="Architecture" width="800"/>
 
 ```
-                                        Logs     --> Kibana
-                                      /                |
-GitHub --> CI --> Kubernetes -->  Job    Prometheus  Elaticsearch
-      \                          /    \  /         \   |
-        ------------------------        Metrics  --> Grafana
+                                        Vector --> Elaticsearch --> Kibana
+                                      / (Logs)         |
+GitHub --> CI --> Kubernetes -->  Job                  |
+      \             /                 \                |
+        -----------                     Prometheus --> Grafana
+                                        (Metrics)
 ```
+ 1. GitHub Actions run a workflow
+ 2. This workflow create a Job in Kubernetes cluster
+ 3. Job run Dist-Tests runner Pod with specified parameters
+ 4. Dists-Tests runner run the tests from inside the Kubernetes and generate the logs
+ 5. Vector ship the logs of the Dists-Tests Pods
+ 6. Prometheus collect the metrics of the Dists-Tests Codex Pods
+ 7. We can see the status of the Dist-Test
 
 
 ### Components

--- a/docs/Continuous-Tests.md
+++ b/docs/Continuous-Tests.md
@@ -1,0 +1,119 @@
+# Continuous Tests
+
+ 1. [Description](#description)
+ 2. [Prerequisites](#prerequisites)
+ 3. [Run tests](#run-tests)
+ 4. [Analyze logs](#analyze-logs)
+
+
+## Description
+
+ Continuous Tests were developed to perform long lasting tests in different configurations and topologies. Unlike Distributed Tests, they are running continuously, until we stop them manually. Such approach is very useful to detect the issues which may appear over the time when we may have blocking I/O, unclosed pools/connections and etc.
+
+ Usually, we are running Continuous Tests manually and for automated runs, please refer to the [Tests automation](Automation.md).
+
+ We have two projects in the repository
+ - [CodexNetDeployer](../CodexNetDeployer) - Prepare environment to run the tests
+ - [ContinuousTests](../ContinuousTests) - Continuous Tests
+
+ And they are used to prepare environment and run Continuous Tests.
+
+
+## Prerequisites
+
+ 1. Kubernetes cluster, to run the tests
+ 2. kubeconfig file, to access the cluster
+ 3. [kubectl](https://kubernetes.io/docs/tasks/tools/) installed, to create resources in the cluster
+ 4. Optional - [OpenLens](https://github.com/MuhammedKalkan/OpenLens) installed, to browse cluster resources
+
+
+## Run tests
+ 1. Create a Pod in the cluster, in the `default` namespace and consider to use your own value for `metadata.name`
+    <details>
+    <summary>tests-runner.yaml</summary>
+
+    ```yaml
+    ---
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: tests-runner
+      namespace: default
+      labels:
+        name: manual-run
+    spec:
+      containers:
+      - name: runner
+        image: mcr.microsoft.com/dotnet/sdk:7.0
+        env:
+        - name: KUBECONFIG
+          value: /opt/kubeconfig.yaml
+      #   volumeMounts:
+      #   - name: kubeconfig
+      #     mountPath: /opt/kubeconfig.yaml
+      #     subPath: kubeconfig.yaml
+      #   - name: logs
+      #    mountPath: /var/log/codex-dist-tests
+        command: ["sleep", "infinity"]
+      # volumes:
+      #   - name: kubeconfig
+      #     secret:
+      #       secretName: codex-dist-tests-app-kubeconfig
+      #   - name: logs
+      #     hostPath:
+      #       path: /var/log/codex-dist-tests
+    ```
+
+    ```shell
+    kubectl apply -f tests-runner.yaml
+    ```
+
+ 2. Copy kubeconfig to the runner
+    ```shell
+    kubectl cp ~/.kube/codex-dist-tests.yaml tests-runner:/opt/kubeconfig.yaml
+    ```
+
+ 3. Exec into the runner Pod using the name you set in the previous step
+    ```shell
+    # kubectl
+    kubectl exec -it tests-runner -- bash
+
+    # OpenLens
+    OpenLens --> Pods --> dist-tests-runner --> "Press on it" --> Pod Shell
+    ```
+
+ 4. Install required packages
+    ```shell
+    apt update
+    apt install -y tmux
+    ```
+
+ 5. Clone c-tests repository
+    ```shell
+    tmux
+
+    cd /opt
+    git clone https://github.com/codex-storage/cs-codex-dist-tests.git
+    ```
+
+ 6. Run `CodexNetDeployer`
+    ```shell
+    # Usually take ~ 10 minutes
+    cd cs-codex-dist-tests/CodexNetDeployer
+
+    export RUNID=$(date +%Y%m%d-%H%M%S)
+    bash deploy-continuous-testnet.sh
+    ```
+
+ 7. Run `ContinuousTests`
+    ```
+    cd ../ContinuousTests
+    cp ../CodexNetDeployer/codex-deployment.json .
+
+    bash run.sh
+    ```
+
+
+## Analyze logs
+
+ We should check the logs in the `/opt/cs-codex-dist-tests/ContinuousTests/logs/` folder


### PR DESCRIPTION
This PR contains basic documentation about how to run Continuous Tests - [Continuous-Tests.md](https://github.com/codex-storage/cs-codex-dist-tests/blob/docs/add-continuous-tests-documentation/docs/Continuous-Tests.md).

We can improve it later, but we at least need some start point now.