### PR TITLE
Decrease Codex Pods resources request

### DIFF
--- a/DistTestCore/Codex/CodexContainerRecipe.cs
+++ b/DistTestCore/Codex/CodexContainerRecipe.cs
@@ -22,7 +22,7 @@ namespace DistTestCore.Codex
         {
             Image = GetDockerImage();
 
-            Resources.Requests = new ContainerResourceSet(milliCPUs: 1000, memory: 6.GB());
+            Resources.Requests = new ContainerResourceSet(milliCPUs: 100, memory: 100.MB());
             Resources.Limits = new ContainerResourceSet(milliCPUs: 4000, memory: 12.GB());
         }
 


### PR DESCRIPTION
This PR decrease resources request for Codex Pods.

We initially agreed to set `4vCPU/4RAM` for Codex Storage nodes, but for Dist-Tests we should start from the lower values

<img width="372" alt="Screenshot 2023-09-18 at 17 16 11" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/ff4515c0-fbe5-472b-ad00-24f4bc0ed5fe">
