### PR TITLE
Pass a command during automated tests run

### DIFF
--- a/.github/workflows/dist-tests.yaml
+++ b/.github/workflows/dist-tests.yaml
@@ -23,11 +23,15 @@ on:
         required: false
         type: string
       nameprefix:
-        description: Runner prefix (cs-codex-dist-tests)
+        description: Runner prefix (codex-dist-tests)
         required: false
         type: string
       namespace:
-        description: Runner namespace (cs-codex-dist-tests)
+        description: Runner namespace (default)
+        required: false
+        type: string
+      command:
+        description: Runner command (dotnet test Tests)
         required: false
         type: string
 
@@ -35,8 +39,9 @@ on:
 env:
   BRANCH: ${{ github.ref_name }}
   SOURCE: ${{ format('{0}/{1}', github.server_url, github.repository) }}
-  NAMEPREFIX: cs-codex-dist-tests
-  NAMESPACE: cs-codex-dist-tests
+  NAMEPREFIX: codex-dist-tests
+  NAMESPACE: default
+  COMMAND: dotnet test Tests
   JOB_MANIFEST: docker/job.yaml
   KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
   KUBE_VERSION: v1.26.1
@@ -56,6 +61,8 @@ jobs:
           [[ -n "${{ github.event.inputs.source }}" ]] && echo "SOURCE=${{ github.event.inputs.source }}" >>"$GITHUB_ENV" || echo "SOURCE=${{ env.SOURCE }}" >>"$GITHUB_ENV"
           [[ -n "${{ github.event.inputs.nameprefix }}" ]] && echo "NAMEPREFIX=${{ github.event.inputs.nameprefix }}" >>"$GITHUB_ENV" || echo "NAMEPREFIX=${{ env.NAMEPREFIX }}" >>"$GITHUB_ENV"
           [[ -n "${{ github.event.inputs.namespace }}" ]] && echo "NAMESPACE=${{ github.event.inputs.namespace }}" >>"$GITHUB_ENV" || echo "NAMESPACE=${{ env.NAMESPACE }}" >>"$GITHUB_ENV"
+          [[ -n "${{ github.event.inputs.command }}" ]] && COMMAND="${{ github.event.inputs.command }}" || COMMAND="${{ env.COMMAND }}"
+          echo "COMMAND=$(jq -c 'split(" ")' <<< '"'$COMMAND'"')" >>"$GITHUB_ENV"
           echo "RUNID=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "TESTID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 

--- a/docker/job.yaml
+++ b/docker/job.yaml
@@ -11,6 +11,10 @@ spec:
   template:
     metadata:
       name: ${NAMEPREFIX}
+      labels:
+        app: dist-tests-runner
+        name: ${NAMEPREFIX}-${RUNID}
+        run-id: ${RUNID}
     spec:
       containers:
       - name: ${NAMEPREFIX}-runner
@@ -20,7 +24,7 @@ spec:
         - name: KUBECONFIG
           value: /opt/kubeconfig.yaml
         - name: LOGPATH
-          value: /var/log/cs-codex-dist-tests
+          value: /var/log/codex-dist-tests
         - name: NAMESPACE
           value: ${NAMESPACE}
         - name: BRANCH
@@ -36,16 +40,13 @@ spec:
           mountPath: /opt/kubeconfig.yaml
           subPath: kubeconfig.yaml
         - name: logs
-          mountPath: /var/log/cs-codex-dist-tests
-        # command:
-        # - "dotnet"
-        # - "test"
-        # - "Tests"
+          mountPath: /var/log/codex-dist-tests
+        args: ${COMMAND}
       restartPolicy: Never
       volumes:
         - name: kubeconfig
           secret:
-            secretName: cs-codex-dist-tests-app-kubeconfig
+            secretName: codex-dist-tests-app-kubeconfig
         - name: logs
           hostPath:
-            path: /var/log/cs-codex-dist-tests
+            path: /var/log/codex-dist-tests


### PR DESCRIPTION
This PR add a way to specify a `command` for container during automated tests run via GitHub Actions.

By default we use `dotnet test Tests`, but also can pass something like `dotnet test --filter=CodexLogExample` for fast checks.

<img width="342" alt="Screenshot 2023-09-19 at 15 19 50" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/59b27387-5c61-45d4-93ea-1fff9b6e6d4b">


We also switched from `cs-codex-dist-tests` to just `codex-dist-tests` in different locations.