### PR TITLE
Show Tests Identification in runners workflows

### DIFF
--- a/.github/workflows/continuous-tests.yaml
+++ b/.github/workflows/continuous-tests.yaml
@@ -14,16 +14,16 @@ on:
   #     - '!docker/continuous-tests-job.yaml'
   workflow_dispatch:
     inputs:
-      branch:
-        description: Branch (master)
-        required: false
-        type: string
       source:
         description: Repository with tests (current)
         required: false
         type: string
+      branch:
+        description: Branch with tests (master)
+        required: false
+        type: string
       nameprefix:
-        description: Runner name prefix (codex-continuous-tests)
+        description: Runner name prefix (c-tests-runner)
         required: false
         type: string
       namespace:
@@ -31,7 +31,7 @@ on:
         required: false
         type: string
       tests_target_duration:
-        description: Runner target duration (172800s=48h)
+        description: Runner target duration (172800 = 48h)
         required: false
         type: string
       tests_filter:
@@ -39,11 +39,14 @@ on:
         required: false
         type: string
       tests_cleanup:
-        description: Runner tests cleanup (true)
-        required: false
-        type: string
+        description: Runner tests cleanup
+        type: choice
+        options:
+        - true
+        - false
+        default: true
       deployment_namespace:
-        description: Deployment namespace (codex-continuous-tests)
+        description: Deployment namespace (c-tests-$runid)
         required: false
         type: string
 
@@ -51,9 +54,9 @@ on:
 env:
   BRANCH: ${{ github.ref_name }}
   SOURCE: ${{ format('{0}/{1}', github.server_url, github.repository) }}
-  NAMEPREFIX: codex-continuous-tests
+  NAMEPREFIX: c-tests-runner
   NAMESPACE: default
-  DEPLOYMENT_NAMESPACE: codex-continuous-tests
+  DEPLOYMENT_NAMESPACE: c-tests
   TESTS_TARGET_DURATION: 172800
   TESTS_FILTER: ""
   TESTS_CLEANUP: true
@@ -72,16 +75,18 @@ jobs:
 
       - name: Variables
         run: |
-          [[ -n "${{ github.event.inputs.branch }}" ]] && echo "BRANCH=${{ github.event.inputs.branch }}" >>"$GITHUB_ENV" || echo "BRANCH=${{ env.BRANCH }}" >>"$GITHUB_ENV"
+          RUNID=$(date +%Y%m%d-%H%M%S)
+          echo "RUNID=${RUNID}" >> $GITHUB_ENV
+          echo "TESTID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           [[ -n "${{ github.event.inputs.source }}" ]] && echo "SOURCE=${{ github.event.inputs.source }}" >>"$GITHUB_ENV" || echo "SOURCE=${{ env.SOURCE }}" >>"$GITHUB_ENV"
+          [[ -n "${{ github.event.inputs.branch }}" ]] && echo "BRANCH=${{ github.event.inputs.branch }}" >>"$GITHUB_ENV" || echo "BRANCH=${{ env.BRANCH }}" >>"$GITHUB_ENV"
           [[ -n "${{ github.event.inputs.nameprefix }}" ]] && echo "NAMEPREFIX=${{ github.event.inputs.nameprefix }}" >>"$GITHUB_ENV" || echo "NAMEPREFIX=${{ env.NAMEPREFIX }}" >>"$GITHUB_ENV"
           [[ -n "${{ github.event.inputs.namespace }}" ]] && echo "NAMESPACE=${{ github.event.inputs.namespace }}" >>"$GITHUB_ENV" || echo "NAMESPACE=${{ env.NAMESPACE }}" >>"$GITHUB_ENV"
           [[ -n "${{ github.event.inputs.tests_target_duration }}" ]] && echo "TESTS_TARGET_DURATION=${{ github.event.inputs.tests_target_duration }}" >>"$GITHUB_ENV" || echo "TESTS_TARGET_DURATION=${{ env.TESTS_TARGET_DURATION }}" >>"$GITHUB_ENV"
           [[ -n "${{ github.event.inputs.tests_filter }}" ]] && echo "TESTS_FILTER=${{ github.event.inputs.tests_filter }}" >>"$GITHUB_ENV" || echo "TESTS_FILTERS=${{ env.TESTS_FILTERS }}" >>"$GITHUB_ENV"
           [[ -n "${{ github.event.inputs.tests_cleanup }}" ]] && echo "TESTS_CLEANUP=${{ github.event.inputs.tests_cleanup }}" >>"$GITHUB_ENV" || echo "TESTS_CLEANUP=${{ env.TESTS_CLEANUP }}" >>"$GITHUB_ENV"
-          [[ -n "${{ github.event.inputs.deployment_namespace }}" ]] && echo "DEPLOYMENT_NAMESPACE=${{ github.event.inputs.deployment_namespace }}" >>"$GITHUB_ENV" || echo "DEPLOYMENT_NAMESPACE=${{ env.DEPLOYMENT_NAMESPACE }}" >>"$GITHUB_ENV"
-          echo "RUNID=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
-          echo "TESTID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          [[ -n "${{ github.event.inputs.deployment_namespace }}" ]] && echo "DEPLOYMENT_NAMESPACE=${{ github.event.inputs.deployment_namespace }}" >>"$GITHUB_ENV" || echo "DEPLOYMENT_NAMESPACE=${{ env.DEPLOYMENT_NAMESPACE }}-${RUNID}" >>"$GITHUB_ENV"
+
       - name: Kubectl - Install ${{ env.KUBE_VERSION }}
         uses: azure/setup-kubectl@v3
         with:
@@ -91,6 +96,21 @@ jobs:
         run: |
           mkdir -p "${HOME}"/.kube
           echo "${{ env.KUBE_CONFIG }}" | base64 -d > "${HOME}"/.kube/config
+
       - name: Kubectl - Create Job
         run: |
           envsubst < ${{ env.JOB_MANIFEST }} | kubectl apply -f -
+
+      - name: Tests Identification
+        run: |
+          echo "----"
+          echo "Repository: ${{ env.SOURCE }}"
+          echo "Branch: ${{ env.BRANCH }}"
+          echo "Runner Pod: ${{ env.NAMEPREFIX }}-${{ env.RUNID }}"
+          echo "Runner namespace: ${{ env.NAMESPACE }}"
+          echo "----"
+          echo "Tests namespace: ${{ env.DEPLOYMENT_NAMESPACE }}"
+          echo "Tests duration: ${{ env.TESTS_TARGET_DURATION }}"
+          echo "Tests filter: ${{ env.TESTS_FILTER }}"
+          echo "Tests cleanup: ${{ env.TESTS_CLEANUP }}"
+          echo "----"

--- a/.github/workflows/dist-tests.yaml
+++ b/.github/workflows/dist-tests.yaml
@@ -14,16 +14,16 @@ on:
   #     - '!docker/dist-tests-job.yaml'
   workflow_dispatch:
     inputs:
-      branch:
-        description: Branch (master)
-        required: false
-        type: string
       source:
         description: Repository with tests (current)
         required: false
         type: string
+      branch:
+        description: Branch with tests (master)
+        required: false
+        type: string
       nameprefix:
-        description: Runner prefix (codex-dist-tests)
+        description: Runner name prefix (d-tests-runner)
         required: false
         type: string
       namespace:
@@ -31,7 +31,7 @@ on:
         required: false
         type: string
       command:
-        description: Runner command (dotnet test Tests)
+        description: Command (dotnet test Tests/CodexTests)
         required: false
         type: string
 
@@ -39,7 +39,7 @@ on:
 env:
   BRANCH: ${{ github.ref_name }}
   SOURCE: ${{ format('{0}/{1}', github.server_url, github.repository) }}
-  NAMEPREFIX: codex-dist-tests
+  NAMEPREFIX: d-tests-runner
   NAMESPACE: default
   COMMAND: dotnet test Tests/CodexTests
   JOB_MANIFEST: docker/dist-tests-job.yaml
@@ -79,3 +79,14 @@ jobs:
       - name: Kubectl - Create Job
         run: |
           envsubst < ${{ env.JOB_MANIFEST }} | kubectl apply -f -
+
+      - name: Tests Identification
+        run: |
+          echo "----"
+          echo "Repository: ${{ env.SOURCE }}"
+          echo "Branch: ${{ env.BRANCH }}"
+          echo "Runner Pod: ${{ env.NAMEPREFIX }}-${{ env.RUNID }}"
+          echo "Runner namespace: ${{ env.NAMESPACE }}"
+          echo "----"
+          echo "Command: `jq -r '. | join(" ")' <<< '${{ env.COMMAND }}'`"
+          echo "----"


### PR DESCRIPTION
This is a cosmetic PR which adds 'Tests Identification' step to "Run Dist/Continuous Tests" workflows which should help us to identify Tests in the Cluster/Grafana/Kibana.

Also, default names for runners were shortered - `d-tests-runner`, `c-tests-runner`.

<img width="1045" alt="Screenshot 2023-11-12 at 16 56 58" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/56b3d829-828a-4211-b6ec-b9bbded5f97b">
<img width="1040" alt="Screenshot 2023-11-12 at 16 58 12" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/38dabe81-5791-42de-8323-5e7ddbd4c719">
<img width="1201" alt="Screenshot 2023-11-12 at 16 59 04" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/7b035964-b766-43ee-85f4-4bc5584d7bbc">
