### PR TITLE
Use separate log folder per Continuous Tests run

### DIFF
--- a/docker/continuous-tests-job.yaml
+++ b/docker/continuous-tests-job.yaml
@@ -30,7 +30,7 @@ spec:
         - name: KUBECONFIG
           value: "/opt/kubeconfig.yaml"
         - name: LOGPATH
-          value: "/var/log/codex-continuous-tests"
+          value: "/var/log/codex-continuous-tests/${DEPLOYMENT_NAMESPACE}"
         - name: NAMESPACE
           value: "${NAMESPACE}"
         - name: BRANCH


### PR DESCRIPTION
When we run Continuous Tests and specify `LOGPATH=/var/log/codex-continuous-tests`, all the logs will be located under the same root folder. Sometimes that may leads to the logs clashes.

This PR add an additional folder level which is equal to the `DEPLOYMENT_NAMESPACE`.