### PR TITLE
Use dedicated node pool for tests runners

### DIFF
--- a/docker/continuous-tests-job.yaml
+++ b/docker/continuous-tests-job.yaml
@@ -18,14 +18,14 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        doks.digitalocean.com/node-pool: "fixed-s-4vcpu-16gb-amd"
+        workload-type: "tests-runners"
       containers:
       - name: ${NAMEPREFIX}-runner
         image: codexstorage/cs-codex-dist-tests:latest
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "2Gi"
+            memory: "1Gi"
         env:
         - name: KUBECONFIG
           value: "/opt/kubeconfig.yaml"

--- a/docker/dist-tests-job.yaml
+++ b/docker/dist-tests-job.yaml
@@ -16,10 +16,16 @@ spec:
         name: ${NAMEPREFIX}-${RUNID}
         run-id: ${RUNID}
     spec:
+      priorityClassName: system-node-critical
+      nodeSelector:
+        workload-type: "tests-runners"
       containers:
       - name: ${NAMEPREFIX}-runner
         image: codexstorage/cs-codex-dist-tests:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "1Gi"
         env:
         - name: KUBECONFIG
           value: "/opt/kubeconfig.yaml"


### PR DESCRIPTION
This PR updates Kubernetes Jobs to use a dedicated nodes pool for tests runners.

Closes https://github.com/codex-storage/infra-codex/issues/88