### PR TITLE
Fix reports workflows scheduler

### DIFF
--- a/.github/workflows/report-HoldMyBeerTest.yaml
+++ b/.github/workflows/report-HoldMyBeerTest.yaml
@@ -3,7 +3,7 @@ name: Report - HoldMyBeerTest
 
 on:
   schedule:
-    - cron: '30 */49 * * *'
+    - cron: '30 * */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/report-PeersTest.yaml
+++ b/.github/workflows/report-PeersTest.yaml
@@ -3,7 +3,7 @@ name: Report - PeersTest
 
 on:
   schedule:
-    - cron: '30 */49 * * *'
+    - cron: '30 * */2 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Cron `'30 */49 * * *'` was not running every 49 hours, but instead every 24 hours.

We should check another option to run every 2 days - `'30 * */2 * *'`.

More details here - [`schedule`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).