### PR TITLE
Auto cleanup old Continuous tests Jobs

### DIFF
--- a/docker/continuous-tests-job.yaml
+++ b/docker/continuous-tests-job.yaml
@@ -7,6 +7,7 @@ metadata:
     name: ${NAMEPREFIX}
     runid: ${RUNID}
 spec:
+  ttlSecondsAfterFinished: 86400
   backoffLimit: 0
   template:
     metadata:


### PR DESCRIPTION
This PR adds a way to cleanup Continuous Tests jobs automatically. It is based on [Clean up finished jobs automatically](https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically).

In that way, Kubernetes Jobs will be deleted automatically after 24 hours and freed up resources on the runners nodes.