### PR TITLE
Adjust C-Tests for autoruns

### DIFF
--- a/.github/workflows/continuous-tests.yaml
+++ b/.github/workflows/continuous-tests.yaml
@@ -30,6 +30,7 @@ on:
         type: string
       tests_cleanup:
         description: Runner tests cleanup
+        required: false
         type: boolean
         default: true
   workflow_call:
@@ -43,7 +44,7 @@ on:
         required: false
         type: string
       codexdockerimage:
-        description: Codex Docker tag (codexstorage/nim-codex:latest-dist-tests)
+        description: Codex Docker image (codexstorage/nim-codex:latest-dist-tests)
         required: false
         type: string
       nameprefix:
@@ -62,6 +63,12 @@ on:
         description: Runner tests cleanup
         required: false
         type: boolean
+        default: true
+      workflow_source:
+        description: Workflow source
+        required: false
+        type: string
+        default: ''
 
 
 env:
@@ -80,11 +87,13 @@ env:
 
 jobs:
   run_tests:
-    name: Run Tests
+    name: Run Continuous Tests ${{ inputs.tests_filter }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.workflow_source }}
 
       - name: Variables
         run: |
@@ -94,8 +103,9 @@ jobs:
           [[ -n "${{ inputs.source }}" ]] && echo "SOURCE=${{ inputs.source }}" >>"$GITHUB_ENV" || echo "SOURCE=${{ env.SOURCE }}" >>"$GITHUB_ENV"
           [[ -n "${{ inputs.branch }}" ]] && echo "BRANCH=${{ inputs.branch }}" >>"$GITHUB_ENV" || echo "BRANCH=${{ env.BRANCH }}" >>"$GITHUB_ENV"
           [[ -n "${{ inputs.codexdockerimage }}" ]] && echo "CODEXDOCKERIMAGE=${{ inputs.codexdockerimage }}" >>"$GITHUB_ENV" || echo "CODEXDOCKERIMAGE=${{ env.CODEXDOCKERIMAGE }}" >>"$GITHUB_ENV"
-          [[ -n "${{ inputs.nameprefix }}" ]] && echo "NAMEPREFIX=${{ inputs.nameprefix }}-${RUNID}" >>"$GITHUB_ENV" || echo "NAMEPREFIX=${{ env.NAMEPREFIX }}-${RUNID}" >>"$GITHUB_ENV"
-          [[ -n "${{ inputs.nameprefix }}" ]] && echo "DEPLOYMENT_NAMESPACE=${{ inputs.nameprefix }}-${RUNID}" >>"$GITHUB_ENV" || echo "DEPLOYMENT_NAMESPACE=${{ env.NAMEPREFIX }}-${RUNID}" >>"$GITHUB_ENV"
+          [[ -n "${{ inputs.nameprefix }}" ]] && NAMEPREFIX="`awk '{ print tolower($0) }' <<< ${{ inputs.nameprefix }}`" || NAMEPREFIX="`awk '{ print tolower($0) }' <<< ${{ env.NAMEPREFIX }}`"
+          echo "NAMEPREFIX=${NAMEPREFIX}-${RUNID}" >>"$GITHUB_ENV"
+          echo "DEPLOYMENT_NAMESPACE=${NAMEPREFIX}-${RUNID}" >>"$GITHUB_ENV"
           [[ -n "${{ inputs.namespace }}" ]] && echo "NAMESPACE=${{ inputs.namespace }}" >>"$GITHUB_ENV" || echo "NAMESPACE=${{ env.NAMESPACE }}" >>"$GITHUB_ENV"
           [[ -n "${{ inputs.tests_target_duration }}" ]] && echo "TESTS_TARGET_DURATION=${{ inputs.tests_target_duration }}" >>"$GITHUB_ENV" || echo "TESTS_TARGET_DURATION=${{ env.TESTS_TARGET_DURATION }}" >>"$GITHUB_ENV"
           [[ -n "${{ inputs.tests_filter }}" ]] && echo "TESTS_FILTER=${{ inputs.tests_filter }}" >>"$GITHUB_ENV" || echo "TESTS_FILTERS=${{ env.TESTS_FILTERS }}" >>"$GITHUB_ENV"


### PR DESCRIPTION
This PR add some small adjustment for Continuous Tests workflow to run C-Tests on commits in the [`nim-codex`](https://github.com/codex-storage/nim-codex) repository.

Appropriate workflows in the mentioned repository will be updated later
 - [`docker-reusable.yml`](https://github.com/codex-storage/nim-codex/blob/master/.github/workflows/docker-reusable.yml)
 - [`docker-dist-tests.yml`](https://github.com/codex-storage/nim-codex/blob/master/.github/workflows/docker-dist-tests.yml)