### PR TITLE
Change affinity label

### DIFF
--- a/Framework/KubernetesWorkflow/K8sController.cs
+++ b/Framework/KubernetesWorkflow/K8sController.cs
@@ -393,7 +393,7 @@ namespace KubernetesWorkflow
                                 {
                                     new V1NodeSelectorRequirement
                                     {
-                                        Key = "workload-type",
+                                        Key = "allow-tests-pods",
                                         OperatorProperty = "NotIn",
                                         Values = notIns
                                     }

--- a/ProjectPlugins/CodexContractsPlugin/CodexContractsContainerRecipe.cs
+++ b/ProjectPlugins/CodexContractsPlugin/CodexContractsContainerRecipe.cs
@@ -21,7 +21,7 @@ namespace CodexContractsPlugin
 
             var address = config.GethNode.StartResult.Container.GetAddress(new NullLog(), GethContainerRecipe.HttpPortTag);
 
-            SetSchedulingAffinity(notIn: "tests-runners");
+            SetSchedulingAffinity(notIn: "false");
 
             AddEnvVar("DISTTEST_NETWORK_URL", address.ToString());
             AddEnvVar("HARDHAT_NETWORK", "codexdisttestnetwork");

--- a/ProjectPlugins/CodexDiscordBotPlugin/DiscordBotContainerRecipe.cs
+++ b/ProjectPlugins/CodexDiscordBotPlugin/DiscordBotContainerRecipe.cs
@@ -13,7 +13,7 @@ namespace CodexDiscordBotPlugin
         {
             var config = startupConfig.Get<DiscordBotStartupConfig>();
 
-            SetSchedulingAffinity(notIn: "tests-runners");
+            SetSchedulingAffinity(notIn: "false");
 
             AddEnvVar("TOKEN", config.Token);
             AddEnvVar("SERVERNAME", config.ServerName);

--- a/ProjectPlugins/CodexPlugin/CodexContainerRecipe.cs
+++ b/ProjectPlugins/CodexPlugin/CodexContainerRecipe.cs
@@ -29,7 +29,7 @@ namespace CodexPlugin
             SetResourcesRequest(milliCPUs: 100, memory: 100.MB());
             //SetResourceLimits(milliCPUs: 4000, memory: 12.GB());
 
-            SetSchedulingAffinity(notIn: "tests-runners");
+            SetSchedulingAffinity(notIn: "false");
             SetSystemCriticalPriority();
 
             var config = startupConfig.Get<CodexStartupConfig>();

--- a/ProjectPlugins/GethPlugin/GethContainerRecipe.cs
+++ b/ProjectPlugins/GethPlugin/GethContainerRecipe.cs
@@ -24,7 +24,7 @@ namespace GethPlugin
 
             var args = CreateArgs(config);
 
-            SetSchedulingAffinity(notIn: "tests-runners");
+            SetSchedulingAffinity(notIn: "false");
             SetSystemCriticalPriority();
 
             AddEnvVar("GETH_ARGS", args);

--- a/ProjectPlugins/MetricsPlugin/PrometheusContainerRecipe.cs
+++ b/ProjectPlugins/MetricsPlugin/PrometheusContainerRecipe.cs
@@ -14,7 +14,7 @@ namespace MetricsPlugin
         {
             var config = startupConfig.Get<PrometheusStartupConfig>();
 
-            SetSchedulingAffinity(notIn: "tests-runners");
+            SetSchedulingAffinity(notIn: "false");
 
             AddExposedPortAndVar("PROM_PORT", PortTag);
             AddEnvVar("PROM_CONFIG", config.PrometheusConfigBase64);


### PR DESCRIPTION
@benbierens,

I've updated affinity label to the `notIn: allow-tests-pods=false`
```yaml
nodeAffinity:
  requiredDuringSchedulingIgnoredDuringExecution:
    nodeSelectorTerms:
      - matchExpressions:
          - key: allow-tests-pods
            operator: NotIn
            values:
              - 'false'
```


Now we have 4 types of node pools
| # | Node prefix  | `workload-type` | `allow-tests-pods` | Scaling     | Description      |
| - | ------------ | --------------- | ------------------ | ----------- | ---------------- |
| 1 | `infra`      | `infra`         | `false`            | `auto`      | Infra resources  |
| 2 | `runners`    | `runners`       | `false`            | `fixed`     | Manual tests run |
| 3 | `runners-ci` | `runners-ci`    | `false`            | `auto`      | CI tests run     |
| 4 | `tests`      | `tests-pods`    | `true`             | `auto`      | Tests Pods       |

In that way, Tests Pods will de scheduled only on the `tests` nodes.

Infra part is done in https://github.com/codex-storage/infra-codex/issues/100
