### PR TITLE
Update Runners Jobs nodeSelector

### DIFF
--- a/docker/continuous-tests-job.yaml
+++ b/docker/continuous-tests-job.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        workload-type: "tests-runners"
+        workload-type: "tests-runners-ci"
       containers:
       - name: ${NAMEPREFIX}-runner
         image: codexstorage/cs-codex-dist-tests:latest

--- a/docker/dist-tests-job.yaml
+++ b/docker/dist-tests-job.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        workload-type: "tests-runners"
+        workload-type: "tests-runners-ci"
       containers:
       - name: ${NAMEPREFIX}-runner
         image: codexstorage/cs-codex-dist-tests:latest


### PR DESCRIPTION
We already added dedicated nodes for Runner CI - https://github.com/codex-storage/infra-codex/issues/96.

This PR updates Runners Jobs manifests to use these new nodes.