### PR TITLE
Update Report workflows

### DIFF
--- a/.github/workflows/report-HoldMyBeerTest.yaml
+++ b/.github/workflows/report-HoldMyBeerTest.yaml
@@ -3,17 +3,17 @@ name: Report - HoldMyBeerTest
 
 on:
   schedule:
-    - cron: '30 * */2 * *'
+    - cron: '30 1 */2 * *'
   workflow_dispatch:
 
 jobs:
   run_tests:
     name: Call runner
-    uses: ./.github/workflows/continuous-tests.yaml
+    uses: ./.github/workflows/run-continuous-tests.yaml
     with:
       source: ${{ format('{0}/{1}', github.server_url, github.repository) }}
       branch: master
-      nameprefix: c-tests-report-holdmybeertest
+      nameprefix: c-tests-report-holdmybeertest-48h
       tests_target_duration: 48h
       tests_filter: HoldMyBeerTest
       tests_cleanup: true

--- a/.github/workflows/report-PeersTest.yaml
+++ b/.github/workflows/report-PeersTest.yaml
@@ -3,17 +3,17 @@ name: Report - PeersTest
 
 on:
   schedule:
-    - cron: '30 * */2 * *'
+    - cron: '30 1 */2 * *'
   workflow_dispatch:
 
 jobs:
   run_tests:
     name: Call runner
-    uses: ./.github/workflows/continuous-tests.yaml
+    uses: ./.github/workflows/run-continuous-tests.yaml
     with:
       source: ${{ format('{0}/{1}', github.server_url, github.repository) }}
       branch: master
-      nameprefix: c-tests-report-peerstest
+      nameprefix: c-tests-report-peerstest-48h
       tests_target_duration: 48h
       tests_filter: PeersTest
       tests_cleanup: true


### PR DESCRIPTION
This is a fix for `Report - HoldMyBeerTest` and `Report - PeersTest` workflows, because reusable workflow was renamed to the `run-continuous-tests.yaml`.

Also, Scheduler was updated to run every 2 days at 01:30 - let's check how it works.