### PR TITLE
Remove preview from MintCommand explorer link

### DIFF
--- a/Tools/BiblioTech/Commands/MintCommand.cs
+++ b/Tools/BiblioTech/Commands/MintCommand.cs
@@ -83,7 +83,7 @@ namespace BiblioTech.Commands
         private string FormatTransactionLink(string transaction)
         {
             var url = $"https://explorer.testnet.codex.storage/tx/{transaction}";
-            return $"- [View on block explorer]({url}){Environment.NewLine}Transaction ID - `{transaction}`";
+            return $"- [View on block explorer](<{url}>){Environment.NewLine}Transaction ID - `{transaction}`";
         }
     }
 }


### PR DESCRIPTION
This PR should remove preview in the `/mint` command link to the Block Explorer.

Now, it shown in the Discord
<img width="699" alt="Screenshot 2023-12-18 at 16 37 36" src="https://github.com/codex-storage/cs-codex-dist-tests/assets/20563034/e748b469-76ac-4c71-980e-6e647e138592">
