### PR TITLE
Disable Report workflows

### DIFF
--- a/.github/workflows/report-HoldMyBeerTest.yaml
+++ b/.github/workflows/report-HoldMyBeerTest.yaml
@@ -2,8 +2,8 @@ name: Report - HoldMyBeerTest
 
 
 on:
-  schedule:
-    - cron: '30 1 */2 * *'
+  # schedule:
+  #   - cron: '30 1 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/report-PeersTest.yaml
+++ b/.github/workflows/report-PeersTest.yaml
@@ -2,8 +2,8 @@ name: Report - PeersTest
 
 
 on:
-  schedule:
-    - cron: '30 1 */2 * *'
+  # schedule:
+  #   - cron: '30 1 */2 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR disable Report workflows and we will enable them later, once we will fix the issue with dynamic NodePort assignment.