### PR TITLE
Updates contracts image to latest working one

### DIFF
--- a/ProjectPlugins/CodexContractsPlugin/CodexContractsContainerRecipe.cs
+++ b/ProjectPlugins/CodexContractsPlugin/CodexContractsContainerRecipe.cs
@@ -7,7 +7,7 @@ namespace CodexContractsPlugin
 {
     public class CodexContractsContainerRecipe : ContainerRecipeFactory
     {
-        public static string DockerImage { get; } = "codexstorage/codex-contracts-eth:latest-dist-tests";
+        public static string DockerImage { get; } = "codexstorage/codex-contracts-eth:sha-b5f3399-dist-tests";
 
         public const string MarketplaceAddressFilename = "/hardhat/deployments/codexdisttestnetwork/Marketplace.json";
         public const string MarketplaceArtifactFilename = "/hardhat/artifacts/contracts/Marketplace.sol/Marketplace.json";


### PR DESCRIPTION
@gmega recently discovered that the `codexstorage/codex-contracts-eth:latest` image has [significant changes](https://github.com/codex-storage/codex-contracts-eth/commits/master/) and break the tests.

Let's use the latest working one, for now.