### PR TITLE
Log pod names so it's easier to match against logs

### DIFF
--- a/Tests/CodexContinuousTests/SingleTestRun.cs
+++ b/Tests/CodexContinuousTests/SingleTestRun.cs
@@ -193,6 +193,7 @@ namespace ContinuousTests
             result.Add("testname", testName);
             result.Add("message", message);
             result.Add("involvedpods", string.Join(",", nodes.Select(n => n.GetName())));
+            result.Add("involvedpodnames", string.Join(",", nodes.Select(n => n.GetPodInfo().Name)));
 
             var error = message.Split(Environment.NewLine).First();
             if (error.Contains(":")) error = error.Substring(1 + error.LastIndexOf(":"));


### PR DESCRIPTION
This is a minor PR which adds the actual pod names into the status log so that mapping from test run to pod logs is easier.