### PR TITLE
ci: use temporary branch for setup-kubectl action

### DIFF
--- a/.github/workflows/run-continuous-tests.yaml
+++ b/.github/workflows/run-continuous-tests.yaml
@@ -112,7 +112,7 @@ jobs:
           [[ -n "${{ inputs.tests_cleanup }}" ]] && echo "TESTS_CLEANUP=${{ inputs.tests_cleanup }}" >>"$GITHUB_ENV" || echo "TESTS_CLEANUP=${{ env.TESTS_CLEANUP }}" >>"$GITHUB_ENV"
 
       - name: Kubectl - Install ${{ env.KUBE_VERSION }}
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@releases/v4.0.0
         with:
           version: ${{ env.KUBE_VERSION }}
 

--- a/.github/workflows/run-dist-tests.yaml
+++ b/.github/workflows/run-dist-tests.yaml
@@ -57,7 +57,7 @@ jobs:
           [[ -n "${{ inputs.command }}" ]] && COMMAND="${{ inputs.command }}" || COMMAND="${{ env.COMMAND }}"
 
       - name: Kubectl - Install ${{ env.KUBE_VERSION }}
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@releases/v4.0.0
         with:
           version: ${{ env.KUBE_VERSION }}
 


### PR DESCRIPTION
PR fixes an issue with the v4 release for [azure/setup-kubectl](https://github.com/Azure/setup-kubectl) action.