### PR TITLE
ci: upldate actions to the latest versions

### DIFF
--- a/.github/workflows/run-continuous-tests.yaml
+++ b/.github/workflows/run-continuous-tests.yaml
@@ -112,7 +112,7 @@ jobs:
           [[ -n "${{ inputs.tests_cleanup }}" ]] && echo "TESTS_CLEANUP=${{ inputs.tests_cleanup }}" >>"$GITHUB_ENV" || echo "TESTS_CLEANUP=${{ env.TESTS_CLEANUP }}" >>"$GITHUB_ENV"
 
       - name: Kubectl - Install ${{ env.KUBE_VERSION }}
-        uses: azure/setup-kubectl@releases/v4.0.0
+        uses: azure/setup-kubectl@v4
         with:
           version: ${{ env.KUBE_VERSION }}
 

--- a/.github/workflows/run-dist-tests.yaml
+++ b/.github/workflows/run-dist-tests.yaml
@@ -57,7 +57,7 @@ jobs:
           [[ -n "${{ inputs.command }}" ]] && COMMAND="${{ inputs.command }}" || COMMAND="${{ env.COMMAND }}"
 
       - name: Kubectl - Install ${{ env.KUBE_VERSION }}
-        uses: azure/setup-kubectl@releases/v4.0.0
+        uses: azure/setup-kubectl@v4
         with:
           version: ${{ env.KUBE_VERSION }}
 


### PR DESCRIPTION
This is a follow up of the #96 and we are switching back to the latest version instead of the release branch.