### PR TITLE
Use just folder as a path for digests upload

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ matrix.target.arch }}
-          path: /tmp/digests/*
+          path: /tmp/digests
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
It make no sense to use a wildcard in the path name for the digest uploads.

Let's use just a folder name.