### PR TITLE
Use multi-stage builds for Rewarder

### DIFF
--- a/Tools/BiblioTech/docker/Dockerfile
+++ b/Tools/BiblioTech/docker/Dockerfile
@@ -1,14 +1,26 @@
 # Variables
-ARG IMAGE=mcr.microsoft.com/dotnet/sdk:7.0
+ARG BUILDER=mcr.microsoft.com/dotnet/sdk:7.0
+ARG IMAGE=${BUILDER}
 ARG APP_HOME=/app
 
-# Create
-FROM ${IMAGE}
+
+# Build
+FROM ${IMAGE} AS builder
 ARG APP_HOME
 
 WORKDIR ${APP_HOME}
 COPY ./Tools/BiblioTech ./Tools/BiblioTech
 COPY ./Framework ./Framework
 COPY ./ProjectPlugins ./ProjectPlugins
-CMD ["dotnet", "run", "--project", "Tools/BiblioTech"]
+RUN dotnet restore Tools/BiblioTech
+RUN dotnet publish Tools/BiblioTech -c Release -o out
 
+
+# Create
+FROM ${IMAGE}
+ARG APP_HOME
+ENV APP_HOME=${APP_HOME}
+
+WORKDIR ${APP_HOME}
+COPY --from=builder ${APP_HOME}/out .
+CMD dotnet ${APP_HOME}/BiblioTech.dll

--- a/Tools/TestNetRewarder/docker/Dockerfile
+++ b/Tools/TestNetRewarder/docker/Dockerfile
@@ -1,13 +1,26 @@
 # Variables
-ARG IMAGE=mcr.microsoft.com/dotnet/sdk:7.0
+ARG BUILDER=mcr.microsoft.com/dotnet/sdk:7.0
+ARG IMAGE=${BUILDER}
 ARG APP_HOME=/app
 
-# Create
-FROM ${IMAGE}
+
+# Build
+FROM ${IMAGE} AS builder
 ARG APP_HOME
 
 WORKDIR ${APP_HOME}
 COPY ./Tools/TestNetRewarder ./Tools/TestNetRewarder
 COPY ./Framework ./Framework
 COPY ./ProjectPlugins ./ProjectPlugins
-CMD ["dotnet", "run", "--project", "Tools/TestNetRewarder"]
+RUN dotnet restore Tools/TestNetRewarder
+RUN dotnet publish Tools/TestNetRewarder -c Release -o out
+
+
+# Create
+FROM ${IMAGE}
+ARG APP_HOME
+ENV APP_HOME=${APP_HOME}
+
+WORKDIR ${APP_HOME}
+COPY --from=builder ${APP_HOME}/out .
+CMD dotnet ${APP_HOME}/TestNetRewarder.dll


### PR DESCRIPTION
@benbierens, I did some experiments with the multi-stage builds for Rewarder based on the [Tutorial: Containerize a .NET app](https://learn.microsoft.com/en-us/dotnet/core/docker/build-container) and [run a manual build](https://github.com/codex-storage/cs-codex-dist-tests/actions/runs/8500402344).

**Previous**
```shell
docker pull codexstorage/codex-rewarderbot:sha-b25c747
time docker run --rm codexstorage/codex-rewarderbot:sha-b25c747

real	0m16.992s
```

**New**
```shell
docker pull codexstorage/codex-rewarderbot:sha-0a8083d
time docker run --rm codexstorage/codex-rewarderbot:sha-0a8083d

real	0m0.798s
```

Can you please check if that works as expected?