### PR TITLE
Add .gitattributes for line endings in .bat, .cmd and .sh scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+# Force bash scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.sh text eol=lf
+
+# Likewise, force cmd and batch scripts to always use crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf


### PR DESCRIPTION
I do remember that we had an issue when some `bat` scripts were edited on non-Windows OS.

PR is based on [.gitattributes Best Practices](https://rehansaeed.com/gitattributes-best-practices/) article and uses example from [dotnet/runtime/.gitattributes](https://github.com/dotnet/runtime/blob/main/.gitattributes).

More information can be found in [Configuring Git to handle line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings) and [gitattributes](https://git-scm.com/docs/gitattributes).