### PR TITLE
Bot assigning 'Altruistic mode' role to user if the CID is valid and unique

### DIFF
--- a/Tools/BiblioTech/Commands/CheckCidCommand.cs
+++ b/Tools/BiblioTech/Commands/CheckCidCommand.cs
@@ -1,4 +1,8 @@
 ﻿using BiblioTech.Options;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
 
 namespace BiblioTech.Commands
 {
@@ -9,10 +13,13 @@ namespace BiblioTech.Commands
             description: "Codex Content-Identifier",
             isRequired: true);
         private readonly CodexCidChecker checker;
+        private readonly CidStorage cidStorage;
+        private const ulong ALTRUISTIC_ROLE_ID = 1286134120379977860;
 
         public CheckCidCommand(CodexCidChecker checker)
         {
             this.checker = checker;
+            this.cidStorage = new CidStorage(Path.Combine(Program.Config.DataPath, "valid_cids.txt"));
         }
 
         public override string Name => "check";
@@ -32,7 +39,78 @@ namespace BiblioTech.Commands
 
             var response = await checker.PerformCheck(cid);
             await Program.AdminChecker.SendInAdminChannel($"User {Mention(user)} used '/{Name}' for cid '{cid}'. Lookup-success: {response.Success}. Message: '{response.Message}' Error: '{response.Error}'");
+
+            if (response.Success)
+            {
+                if (cidStorage.IsCidUsed(cid))
+                {
+                    await context.Followup($"{response.Message}\n\nThis CID has already been used by another user. No role will be granted.");
+                    return;
+                }
+
+                if (cidStorage.AddCid(cid, user.Id))
+                {
+                    var guildUser = context.Command.User as IGuildUser;
+                    if (guildUser != null)
+                    {
+                        try
+                        {
+                            var role = context.Command.Guild.GetRole(ALTRUISTIC_ROLE_ID);
+                            if (role != null)
+                            {
+                                await guildUser.AddRoleAsync(role);
+                                await context.Followup($"{response.Message}\n\nCongratulations! You've been granted the Altruistic Mode role for checking a valid CID!");
+                                return;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            await Program.AdminChecker.SendInAdminChannel($"Failed to grant Altruistic Mode role to user {Mention(user)}: {ex.Message}");
+                        }
+                    }
+                }
+            }
+
             await context.Followup(response.Message);
+        }
+    }
+
+    public class CidStorage
+    {
+        private readonly string filePath;
+        private static readonly object _lock = new object();
+
+        public CidStorage(string filePath)
+        {
+            this.filePath = filePath;
+            if (!File.Exists(filePath))
+            {
+                File.WriteAllText(filePath, string.Empty);
+            }
+        }
+
+        public bool AddCid(string cid, ulong userId)
+        {
+            lock (_lock)
+            {
+                var existingEntries = File.ReadAllLines(filePath);
+                if (existingEntries.Any(line => line.Split(',')[0] == cid))
+                {
+                    return false;
+                }
+
+                File.AppendAllText(filePath, $"{cid},{userId}{Environment.NewLine}");
+                return true;
+            }
+        }
+
+        public bool IsCidUsed(string cid)
+        {
+            lock (_lock)
+            {
+                var existingEntries = File.ReadAllLines(filePath);
+                return existingEntries.Any(line => line.Split(',')[0] == cid);
+            }
         }
     }
 }

--- a/Tools/BiblioTech/Configuration.cs
+++ b/Tools/BiblioTech/Configuration.cs
@@ -26,6 +26,9 @@ namespace BiblioTech
         [Uniform("chain-events-channel-id", "cc", "CHAINEVENTSCHANNELID", false, "ID of the Discord server channel where chain events will be posted.")]
         public ulong ChainEventsChannelId { get; set; }
 
+        [Uniform("altruistic-role-id", "ar", "ALTRUISTICROLE", true, "ID of the Discord server role for Altruistic Mode.")]
+        public ulong AltruisticRoleId { get; set; }
+
         [Uniform("reward-api-port", "rp", "REWARDAPIPORT", true, "TCP listen port for the reward API.")]
         public int RewardApiPort { get; set; } = 31080;
 


### PR DESCRIPTION
If the CID exists in the testnet and hasn't been used before:
- Stores the CID and grants the 'Altruistic Mode' role
- Sends a message informing the user that the role has been assigned

If the CID exists but has been used before:
- Informs the user that the CID was already used

If the CID doesn't exist:
- Shows the normal error message