### PR TITLE
Add workflow_source to the inputs when workflow is called

### DIFF
--- a/.github/workflows/run-release-tests.yaml
+++ b/.github/workflows/run-release-tests.yaml
@@ -14,6 +14,11 @@ on:
         description: "Codex Docker image (example: 'codexstorage/nim-codex:0.1.8-dist-tests')"
         required: true
         type: string
+      workflow_source:
+        description: Workflow source
+        required: false
+        type: string
+        default: ''
 
 
 env:


### PR DESCRIPTION
When we call a workflow, we should pass `workflow_source` which was missed in the inputs at that event.

Part of #108.