### PR TITLE
Pass repository and branch to release tests workflow

### DIFF
--- a/.github/workflows/run-release-tests.yaml
+++ b/.github/workflows/run-release-tests.yaml
@@ -10,6 +10,14 @@ on:
         type: string
   workflow_call:
     inputs:
+      source:
+        description: Repository with tests (current)
+        required: false
+        type: string
+      branch:
+        description: Branch with tests (master)
+        required: false
+        type: string
       codexdockerimage:
         description: "Codex Docker image (example: 'codexstorage/nim-codex:0.1.8-dist-tests')"
         required: true
@@ -19,7 +27,6 @@ on:
         required: false
         type: string
         default: ''
-
 
 env:
   SOURCE: ${{ format('{0}/{1}', github.server_url, github.repository) }}


### PR DESCRIPTION
When we call `run-release-tests.yaml` from a remote repository, in the current configuration it will set `source` and `branch` base on the remote repository values.

PR fixes that and pass [`cs-codex-dist-tests`](https://github.com/codex-storage/cs-codex-dist-tests) repository and its main branch as we are doing that currently in the [`run-continuous-tests.yaml`](https://github.com/codex-storage/cs-codex-dist-tests/blob/master/.github/workflows/run-continuous-tests.yaml).

Part of #108.