### PR TITLE
ci: run-release-tests workflow adjustment

### DIFF
--- a/.github/workflows/run-release-tests.yaml
+++ b/.github/workflows/run-release-tests.yaml
@@ -109,6 +109,7 @@ jobs:
           # Get logs
           while [[ $(kubectl get pod ${pod} -n ${namespace} -o jsonpath='{.status.phase}') == "Running" ]]; do
             echo "Show ${pod} logs ..."
+            echo "----"
             kubectl logs $pod -n $namespace -f || true
             sleep 1
           done


### PR DESCRIPTION
This is a #108 followup and it adds a delimiter line, to distinguish runner pod logs easier.