### PR TITLE
feat: add --no-bootstrap-node option via WithNoBootstrapNodes()

### DIFF
--- a/ProjectPlugins/StoragePlugin/ContainerRecipe.cs
+++ b/ProjectPlugins/StoragePlugin/ContainerRecipe.cs
@@ -67,6 +67,10 @@ namespace StoragePlugin
             {
                 AddEnvVar("STORAGE_BOOTSTRAP_NODE", config.BootstrapSpr);
             }
+            if (config.NoBootstrapNodes)
+            {
+                AddEnvVar("STORAGE_NO_BOOTSTRAP_NODE", "true");
+            }
             if (config.StorageQuota != null)
             {
                 AddEnvVar("STORAGE_STORAGE_QUOTA", config.StorageQuota.SizeInBytes.ToString()!);

--- a/ProjectPlugins/StoragePlugin/LogosStorageProcessRecipe.cs
+++ b/ProjectPlugins/StoragePlugin/LogosStorageProcessRecipe.cs
@@ -72,6 +72,10 @@ namespace StoragePlugin
             {
                 AddArg("--bootstrap-node", config.BootstrapSpr);
             }
+            if (config.NoBootstrapNodes)
+            {
+                AddArg("--no-bootstrap-node");
+            }
             if (config.StorageQuota != null)
             {
                 AddArg("--storage-quota", config.StorageQuota.SizeInBytes.ToString()!);
@@ -120,6 +124,11 @@ namespace StoragePlugin
         private void AddArg(string arg, int val)
         {
             args.Add($"{arg}={val}");
+        }
+
+        private void AddArg(string arg)
+        {
+            args.Add(arg);
         }
     }
 }

--- a/ProjectPlugins/StoragePlugin/LogosStorageSetup.cs
+++ b/ProjectPlugins/StoragePlugin/LogosStorageSetup.cs
@@ -12,6 +12,7 @@ namespace StoragePlugin
         ILogosStorageSetup WithLogLevel(LogosStorageLogLevel level);
         ILogosStorageSetup WithLogLevel(LogosStorageLogLevel level, LogosStorageLogCustomTopics customTopics);
         ILogosStorageSetup WithLogFormat(LogosStorageLogFormat format);
+        ILogosStorageSetup WithNoBootstrapNodes();
         ILogosStorageSetup WithStorageQuota(ByteSize storageQuota);
         ILogosStorageSetup WithBlockTTL(TimeSpan duration);
         ILogosStorageSetup WithBlockMaintenanceInterval(TimeSpan duration);
@@ -86,6 +87,12 @@ namespace StoragePlugin
         public ILogosStorageSetup WithLogFormat(LogosStorageLogFormat format)
         {
             LogFormat = format;
+            return this;
+        }
+
+        public ILogosStorageSetup WithNoBootstrapNodes()
+        {
+            NoBootstrapNodes = true;
             return this;
         }
 

--- a/ProjectPlugins/StoragePlugin/LogosStorageStartupConfig.cs
+++ b/ProjectPlugins/StoragePlugin/LogosStorageStartupConfig.cs
@@ -13,6 +13,7 @@ namespace StoragePlugin
         public LogosStorageLogCustomTopics? CustomTopics { get; set; } = new LogosStorageLogCustomTopics(LogosStorageLogLevel.Info, LogosStorageLogLevel.Warn);
         public ByteSize? StorageQuota { get; set; }
         public bool MetricsEnabled { get; set; }
+        public bool NoBootstrapNodes { get; set; }
         public string? BootstrapSpr { get; set; }
         public int? BlockTTL { get; set; }
         public bool? EnableValidator { get; set; }

--- a/Tests/ExperimentalTests/AutoBootstrapDistTest.cs
+++ b/Tests/ExperimentalTests/AutoBootstrapDistTest.cs
@@ -14,7 +14,7 @@ namespace LogosStorageTests
         public void SetupBootstrapNode()
         {
             isBooting = true;
-            BootstrapNode = StartLogosStorage(s => s.WithName("BOOTSTRAP_" + GetTestNamespace()).WithLogFormat(LogosStorageLogFormat.Json));
+            BootstrapNode = StartLogosStorage(s => s.WithName("BOOTSTRAP_" + GetTestNamespace()).WithLogFormat(LogosStorageLogFormat.Json).WithNoBootstrapNodes());
             isBooting = false;
         }
 


### PR DESCRIPTION
Follows the same pattern as --log-format / WithLogFormat():
- NoBootstrapNodes bool property on LogosStorageStartupConfig
- WithNoBootstrapNodes() method on ILogosStorageSetup
- Passes --no-bootstrap-node CLI flag in LogosStorageProcessRecipe
- Sets STORAGE_NO_BOOTSTRAP_NODE=true env var in ContainerRecipe
- Applied to bootstrap nodes in AutoBootstrapDistTest

This will fix the failing release test that checks all peers in the network are connected (by comparing peer tables), since the initial bootstrap node was connecting to external bootstrap nodes (eg `logos.dev`), but the other peers in the network were not connecting to those bootstrap nodes, failing the test.

## Note
~~Depends on https://github.com/logos-storage/logos-storage-nim/pull/1438~~