### PR TITLE
feat: force pod spread to one-per-node per test-namespace

### DIFF
--- a/Framework/KubernetesWorkflow/K8sController.cs
+++ b/Framework/KubernetesWorkflow/K8sController.cs
@@ -375,6 +375,7 @@ namespace KubernetesWorkflow
                             PriorityClassName = GetPriorityClassName(containerRecipes),
                             NodeSelector = CreateNodeSelector(location, containerRecipes),
                             Tolerations = CreateTolerations(containerRecipes),
+                            Affinity = CreateSpreadAffinity(),
                             Containers = CreateDeploymentContainers(containerRecipes),
                             Volumes = CreateVolumes(containerRecipes)
                         }
@@ -420,6 +421,34 @@ namespace KubernetesWorkflow
                 Value = t.Value,
                 Effect = t.Effect
             }).ToList();
+        }
+
+        private V1Affinity CreateSpreadAffinity()
+        {
+            return new V1Affinity
+            {
+                PodAntiAffinity = new V1PodAntiAffinity
+                {
+                    RequiredDuringSchedulingIgnoredDuringExecution = new List<V1PodAffinityTerm>
+                    {
+                        new V1PodAffinityTerm
+                        {
+                            TopologyKey = "kubernetes.io/hostname",
+                            LabelSelector = new V1LabelSelector
+                            {
+                                MatchExpressions = new List<V1LabelSelectorRequirement>
+                                {
+                                    new V1LabelSelectorRequirement
+                                    {
+                                        Key = PodLabelKey,
+                                        OperatorProperty = "Exists"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
         }
 
         private K8sNodeLabel? GetNodeLabelForLocation(ILocation location)


### PR DESCRIPTION
Added required pod anti-affinity (kubernetes.io/hostname, pod-uuid Exists) to K8sController.cs so all pods within a test namespace are forced onto distinct nodes (pods remain Pending if unsatisfiable and the test will timeout) to cover the worst-case pod counts per namespace.

The anti-affinity TopologyKey of "kubernetes.io/hostname" specifies that the domain is the node, along with the "Exists" operator, specifies that "this Pod should _not_ run on this node if this node is already running one or mode pods that have a "pod-uuid" key (they all do). This anti-affinity logic is applied _per test namespace_, where each test defines its own namespace. That means that when concurrently running tests, pods for Test A and Test B could be spread amongst the same nodes, however there will never be a two pods for Test A on the same node.