### PR TITLE
chore: update openapi.yaml and regenerate client

### DIFF
--- a/ProjectPlugins/LogosStorageClient/LogosStorageTypes.cs
+++ b/ProjectPlugins/LogosStorageClient/LogosStorageTypes.cs
@@ -7,8 +7,11 @@ namespace LogosStorageClient
     {
         public string[] Addrs { get; set; } = Array.Empty<string>();
         public string Spr { get; set; } = string.Empty;
+        public string ProviderRecord { get; set; } = string.Empty;
         public string Id { get; set; } = string.Empty;
         public string[] AnnounceAddresses { get; set; } = Array.Empty<string>();
+        public string Libp2pPubKey { get; set; } = string.Empty;
+        public string MixPubKey { get; set; } = string.Empty;
         public DebugInfoVersion Version { get; set; } = new();
         public DebugInfoTable Table { get; set; } = new();
     }

--- a/ProjectPlugins/LogosStorageClient/Mapper.cs
+++ b/ProjectPlugins/LogosStorageClient/Mapper.cs
@@ -12,8 +12,11 @@ namespace LogosStorageClient
             {
                 Id = debugInfo.Id,
                 Spr = debugInfo.Spr,
+                ProviderRecord = debugInfo.ProviderRecord,
                 Addrs = debugInfo.Addrs.ToArray(),
                 AnnounceAddresses = debugInfo.AnnounceAddresses.ToArray(),
+                Libp2pPubKey = debugInfo.Libp2pPubKey,
+                MixPubKey = debugInfo.MixPubKey,
                 Version = Map(debugInfo.Storage),
                 Table = Map(debugInfo.Table)
             };

--- a/ProjectPlugins/LogosStorageClient/openapi.yaml
+++ b/ProjectPlugins/LogosStorageClient/openapi.yaml
@@ -58,11 +58,11 @@ components:
     Node:
       type: object
       required:
-       - nodeId
-       - peerId
-       - record
-       - address
-       - seen
+        - nodeId
+        - peerId
+        - record
+        - address
+        - seen
       properties:
         nodeId:
           type: string
@@ -88,8 +88,8 @@ components:
     PeersTable:
       type: object
       required:
-       - localNode
-       - nodes
+        - localNode
+        - nodes
       properties:
         localNode:
           $ref: "#/components/schemas/Node"
@@ -103,9 +103,9 @@ components:
       required:
         - id
         - addrs
-        - repo
         - spr
         - announceAddresses
+        - libp2pPubKey
         - table
         - storage
       properties:
@@ -115,15 +115,20 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/MultiAddress"
-        repo:
-          type: string
-          description: Path of the data repository where all nodes data are stored
         spr:
+          $ref: "#/components/schemas/SPR"
+        providerRecord:
           $ref: "#/components/schemas/SPR"
         announceAddresses:
           type: array
           items:
             $ref: "#/components/schemas/MultiAddress"
+        libp2pPubKey:
+          type: string
+          description: Hex-encoded libp2p public key of the node
+        mixPubKey:
+          type: string
+          description: Hex-encoded mix public key (present only for nodes that support mix)
         table:
           $ref: "#/components/schemas/PeersTable"
         storage:

--- a/ProjectPlugins/StoragePlugin/ApiChecker.cs
+++ b/ProjectPlugins/StoragePlugin/ApiChecker.cs
@@ -10,7 +10,7 @@ namespace StoragePlugin
     public class ApiChecker
     {
         // <INSERT-OPENAPI-YAML-HASH>
-        private const string OpenApiYamlHash = "47-B8-22-44-3B-51-EB-82-CC-C1-DD-56-F0-7E-EC-7F-CD-E0-8F-5E-F6-3B-40-E0-02-E6-71-DB-B8-03-65-18";
+        private const string OpenApiYamlHash = "F8-A3-C0-20-EA-02-23-36-1C-80-B5-31-68-D8-C4-94-7F-C5-4A-E9-2C-90-89-3F-C8-45-84-54-3A-D8-3E-B7";
         private const string OpenApiFilePath = "/logosstorage/openapi.yaml";
         private const string DisableEnvironmentVariable = "StoragePlugin_DISABLE_APICHECK";
 


### PR DESCRIPTION
This PR updates the openapi.yaml spec for the Logos Storage client and regenerates ApiChecker from the template with an updated hash.
